### PR TITLE
Updated CMAQ open_mfdataset.

### DIFF
--- a/monetio/models/cmaq.py
+++ b/monetio/models/cmaq.py
@@ -115,7 +115,7 @@ def open_mfdataset(
     """
 
     # open the dataset using xarray
-    dset = xr.open_mfdataset(fname, concat_dim="TSTEP", **kwargs)
+    dset = xr.open_mfdataset(fname, combine='nested', concat_dim="TSTEP", **kwargs)
 
     # add lazy diagnostic variables
     dset = add_lazy_pm25(dset)

--- a/monetio/models/cmaq.py
+++ b/monetio/models/cmaq.py
@@ -115,7 +115,7 @@ def open_mfdataset(
     """
 
     # open the dataset using xarray
-    dset = xr.open_mfdataset(fname, combine='nested', concat_dim="TSTEP", **kwargs)
+    dset = xr.open_mfdataset(fname, combine="nested", concat_dim="TSTEP", **kwargs)
 
     # add lazy diagnostic variables
     dset = add_lazy_pm25(dset)


### PR DESCRIPTION
Recently tried to use monetio to read in multiple CMAQ files, and there was an issue when combining multiple files along a specified dimension:

ValueError: When combine='by_coords', passing a value for `concat_dim` has no effect. To manually combine along a specific dimension you should instead specify combine='nested' along with a value for `concat_dim`.