### PR TITLE
Remove module-level Dask progress bar registration

### DIFF
--- a/monetio/obs/aqs.py
+++ b/monetio/obs/aqs.py
@@ -3,15 +3,10 @@ import os
 import warnings
 
 import pandas as pd
-from dask.diagnostics import ProgressBar
 
 from .epa_util import read_monitor_file
 
 # this is a class to deal with aqs data
-
-
-pbar = ProgressBar()
-pbar.register()
 
 
 def add_data(

--- a/monetio/obs/ish.py
+++ b/monetio/obs/ish.py
@@ -1,13 +1,8 @@
 """Python module for reading NOAA ISH files"""
-
-
 import dask
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-from dask.diagnostics import ProgressBar
-
-ProgressBar().register()
 
 
 def add_data(self, dates, box=None, country=None, state=None, site=None, resample=True, window="H"):

--- a/monetio/obs/ish_lite.py
+++ b/monetio/obs/ish_lite.py
@@ -1,11 +1,6 @@
 """Python module for reading NOAA ISH files"""
-
-
 import numpy as np
 import pandas as pd
-from dask.diagnostics import ProgressBar
-
-ProgressBar().register()
 
 
 def add_data(

--- a/monetio/sat/modis_ornl.py
+++ b/monetio/sat/modis_ornl.py
@@ -20,7 +20,6 @@ import sys
 from copy import copy
 
 import numpy as np
-from dask.diagnostics import ProgressBar
 
 try:
     from suds.client import Client
@@ -32,9 +31,6 @@ except ImportError:
 DEBUG_PRINTING = False
 
 defaultURL = "https://modis.ornl.gov/cgi-bin/MODIS/soapservice/MODIS_soapservice.wsdl"
-
-pbar = ProgressBar()
-pbar.register()
 
 
 class modisData:


### PR DESCRIPTION
Resolves #73 

The issue is that the way the monetio is currently set up, all that code gets run when you import `monetio`, so you get progress bars even if you don't want them (e.g. for job logs).