### PR TITLE
Short fix to _cesm_se_mm reader for cases in which only surface variables are present in the var_list.

### DIFF
--- a/monetio/models/_cesm_se_mm.py
+++ b/monetio/models/_cesm_se_mm.py
@@ -58,6 +58,8 @@ def open_mfdataset(
         var_list.append("lat")
     if "lon" not in var_list:
         var_list.append("lon")
+    if "lev" not in var_list:
+        var_list.append("lev")
 
     # ===========================
     # Process the loaded data


### PR DESCRIPTION
Append lev to var_list if not present, otherwise the rename of lev to z will fail in cases in which only surface variables are being read.