### PR TITLE
AERONET interp for daily product

### DIFF
--- a/monetio/obs/aeronet.py
+++ b/monetio/obs/aeronet.py
@@ -526,12 +526,13 @@ class AERONET:
             new_wv = np.asarray(new_wv)
 
             # df_aod_nu = self._aeronet_aod_and_nu(row)
-            aod_columns = [aod_column for aod_column in row.index if "aod_" in aod_column]
+            aod_columns = [aod_column for aod_column in row.index if aod_column.startswith("aod_")]
             aods = row[aod_columns]
             wv = [
                 float(aod_column.replace("aod_", "").replace("nm", ""))
                 for aod_column in aod_columns
             ]
+            # TODO: the non-daily product has `exact_wavelengths_of_aod(um)_<wavelength>nm` that could be used
             a = pd.DataFrame({"aod": aods}).reset_index()
             a["wv"] = wv
             df_aod_nu = a.dropna()

--- a/monetio/obs/aeronet.py
+++ b/monetio/obs/aeronet.py
@@ -1,6 +1,7 @@
 """
 AERONET
 """
+import warnings
 from datetime import datetime
 from functools import lru_cache
 
@@ -551,6 +552,21 @@ class AERONET:
         )
         names = "aod_" + pd.Series(self.new_aod_values.astype(int).astype(str)) + "nm"
         out.columns = names.values
+        dup_names = list(set(self.df) & set(out))
+        if dup_names:
+            # Rename old cols, assuming preference for the specified new wavelengths
+            suff = "_orig"
+            warnings.warn(
+                f"Renaming duplicate AOD columns {dup_names} by adding suffix '{suff}'.",
+                stacklevel=2,
+            )
+            for name in dup_names:
+                self.df = self.df.rename(columns={name: f"{name}{suff}"})
+                if self.daily == 10:  # all data
+                    wl = name[4:-2]
+                    ename = f"exact_wavelengths_of_aod(um)_{wl}nm"
+                    ename_new = f"exact_wavelengths_of_aod(um)_{wl}nm{suff}"
+                    self.df = self.df.rename(columns={ename: ename_new})
         self.df = pd.concat([self.df, out], axis=1)
 
     # @staticmethod

--- a/tests/test_aeronet.py
+++ b/tests/test_aeronet.py
@@ -186,7 +186,8 @@ def test_interp_with_pytspack():
     # For MM data proc example
     dates = pd.date_range(start="2019-09-01", end="2019-09-2", freq="H")
     standard_wavelengths = np.array([0.34, 0.44, 0.55, 0.66, 0.86, 1.63, 11.1]) * 1000
-    df = aeronet.add_data(dates, n_procs=1, interp_to_aod_values=standard_wavelengths)
+    with pytest.warns(UserWarning, match="Renaming duplicate AOD columns"):
+        df = aeronet.add_data(dates, n_procs=1, interp_to_aod_values=standard_wavelengths)
     # Note: default wls for this period:
     #
     # wls = sorted(df.columns[df.columns.str.startswith("aod")].str.slice(4, -2).astype(int).tolist())
@@ -198,14 +199,24 @@ def test_interp_with_pytspack():
     #  870, 1020, 1640]
     #
     # Note: Some of the ones we want already are in there (340 and 440 nm)
-    # TODO: add `_old` to the old ones or `_new` to the new ones? Or remove the old ones?
+
+    # Check for the new columns
     assert {f"aod_{int(wl)}nm" for wl in standard_wavelengths}.issubset(df.columns)
+
+    # Check for renamed duplicate columns
+    assert {c for c in df if c.startswith("aod_") and c.endswith("nm_orig")} == {
+        "aod_340nm_orig",
+        "aod_440nm_orig",
+    }
+    assert {
+        c for c in df if c.startswith("exact_wavelengths_of_aod") and c.endswith("nm_orig")
+    } == {"exact_wavelengths_of_aod(um)_340nm_orig", "exact_wavelengths_of_aod(um)_440nm_orig"}
 
 
 @pytest.mark.skipif(not has_pytspack, reason="no pytspack")
 def test_interp_daily_with_pytspack():
     dates = pd.date_range(start="2019-09-01", end="2019-09-2", freq="H")
-    standard_wavelengths = np.array([0.34, 0.44, 0.55, 0.66, 0.86, 1.63, 11.1]) * 1000
+    standard_wavelengths = np.array([0.55]) * 1000
     df = aeronet.add_data(dates, daily=True, n_procs=1, interp_to_aod_values=standard_wavelengths)
 
     assert {f"aod_{int(wl)}nm" for wl in standard_wavelengths}.issubset(df.columns)

--- a/tests/test_aeronet.py
+++ b/tests/test_aeronet.py
@@ -200,3 +200,13 @@ def test_interp_with_pytspack():
     # Note: Some of the ones we want already are in there (340 and 440 nm)
     # TODO: add `_old` to the old ones or `_new` to the new ones? Or remove the old ones?
     assert {f"aod_{int(wl)}nm" for wl in standard_wavelengths}.issubset(df.columns)
+
+
+@pytest.mark.skipif(not has_pytspack, reason="no pytspack")
+def test_interp_daily_with_pytspack():
+    dates = pd.date_range(start="2019-09-01", end="2019-09-2", freq="H")
+    standard_wavelengths = np.array([0.34, 0.44, 0.55, 0.66, 0.86, 1.63, 11.1]) * 1000
+    with pytest.raises(ValueError):
+        _ = aeronet.add_data(
+            dates, daily=True, n_procs=1, interp_to_aod_values=standard_wavelengths
+        )

--- a/tests/test_aeronet.py
+++ b/tests/test_aeronet.py
@@ -206,7 +206,6 @@ def test_interp_with_pytspack():
 def test_interp_daily_with_pytspack():
     dates = pd.date_range(start="2019-09-01", end="2019-09-2", freq="H")
     standard_wavelengths = np.array([0.34, 0.44, 0.55, 0.66, 0.86, 1.63, 11.1]) * 1000
-    with pytest.raises(ValueError):
-        _ = aeronet.add_data(
-            dates, daily=True, n_procs=1, interp_to_aod_values=standard_wavelengths
-        )
+    df = aeronet.add_data(dates, daily=True, n_procs=1, interp_to_aod_values=standard_wavelengths)
+
+    assert {f"aod_{int(wl)}nm" for wl in standard_wavelengths}.issubset(df.columns)


### PR DESCRIPTION
Resolves #82 

* Fix AOD column identification so that interp works for the daily product, which has some different columns
* Warn and rename old AOD column(s) when a requested wavelength to interp to is the same as one of the existing nominal wavelength columns