### PR TITLE
_gridded_eos_mm.py reader for gridded NASA EOS hdf files

### DIFF
--- a/monetio/sat/__init__.py
+++ b/monetio/sat/__init__.py
@@ -1,4 +1,5 @@
 from . import (
+    _gridded_eos_mm,
     _modis_l2_mm,
     _omps_nadir_mm,
     goes,
@@ -9,6 +10,7 @@ from . import (
 )
 
 __all__ = [
+    "_gridded_eos_mm",
     "_modis_l2_mm",
     "_omps_nadir_mm",
     "nesdis_edr_viirs",

--- a/monetio/sat/_gridded_eos_mm.py
+++ b/monetio/sat/_gridded_eos_mm.py
@@ -4,7 +4,7 @@ import numpy as np
 import xarray as xr
 
 
-def read_gridded_eos(fname, var_dict, save_as_netcdf=False):
+def read_gridded_eos(fname, var_dict, *, save_as_netcdf=False):
     """
     Parameters
     __________
@@ -12,8 +12,8 @@ def read_gridded_eos(fname, var_dict, save_as_netcdf=False):
         Input file path.
     var_dict : dict
         Dictionary of variables to read, along with variable metadata.
-        {varname: {"fillvalue": float, "scale": float, "units": str}, ...}
-    save_as_netcdf: bool, default=False
+        ``{varname: {"fillvalue": float, "scale": float, "units": str}, ...}``
+    save_as_netcdf : bool, default=False
         Save variables in var_dict in netcdf format.
 
 
@@ -22,7 +22,7 @@ def read_gridded_eos(fname, var_dict, save_as_netcdf=False):
     xarray.Dataset
     """
 
-    from monetio.sat.hdfio import hdf_close, hdf_list, hdf_open, hdf_read
+    from .hdfio import hdf_close, hdf_list, hdf_open, hdf_read
 
     logger = logging.getLogger(__name__)
 
@@ -34,8 +34,8 @@ def read_gridded_eos(fname, var_dict, save_as_netcdf=False):
 
     lon = hdf_read(f, "XDim")
     lat = np.flip(hdf_read(f, "YDim"))
-    lon_da = xr.DataArray(lon, attrs={"longname": "longitude", "units": "deg East"})
-    lat_da = xr.DataArray(lat, attrs={"longname": "latitude", "units": "deg North"})
+    lon_da = xr.DataArray(lon, attrs={"long_name": "longitude", "units": "deg east"})
+    lat_da = xr.DataArray(lat, attrs={"long_name": "latitude", "units": "deg north"})
 
     for var in var_dict:
         logger.info("read_gridded_eos:" + var)

--- a/monetio/sat/_gridded_eos_mm.py
+++ b/monetio/sat/_gridded_eos_mm.py
@@ -1,8 +1,7 @@
 import logging
+
 import numpy as np
 import xarray as xr
-
-import monetio
 
 
 def read_gridded_eos(fname, var_dict, save_as_netcdf=False):
@@ -13,7 +12,7 @@ def read_gridded_eos(fname, var_dict, save_as_netcdf=False):
         Input file path.
     var_dict : dict
         Dictionary of variables to read, along with variable metadata.
-        {varname: {'fillvalue': float, 'scale': float, 'units': str}, ...}
+        {varname: {"fillvalue": float, "scale": float, "units": str}, ...}
     save_as_netcdf: bool, default=False
         Save variables in var_dict in netcdf format.
 
@@ -23,31 +22,31 @@ def read_gridded_eos(fname, var_dict, save_as_netcdf=False):
     xarray.Dataset
     """
 
-    from monetio.sat.hdfio import hdf_open, hdf_close, hdf_list, hdf_read
+    from monetio.sat.hdfio import hdf_close, hdf_list, hdf_open, hdf_read
 
     ds_dict = dict()
 
-    logging.info('read_gridded_eos:' + fname)
+    logging.info("read_gridded_eos:" + fname)
     f = hdf_open(fname)
     datasets, indices = hdf_list(f)
 
-    lon = hdf_read(f, 'XDim')
-    lat = np.flip(hdf_read(f, 'YDim'))
-    lon_da = xr.DataArray(lon,
-        attrs={'longname': 'longitude', 'units': 'deg East'})
-    lat_da = xr.DataArray(lat,
-        attrs={'longname': 'latitude', 'units': 'deg North'})
+    lon = hdf_read(f, "XDim")
+    lat = np.flip(hdf_read(f, "YDim"))
+    lon_da = xr.DataArray(lon, attrs={"longname": "longitude", "units": "deg East"})
+    lat_da = xr.DataArray(lat, attrs={"longname": "latitude", "units": "deg North"})
 
     for var in var_dict:
-        logging.info('read_gridded_eos:' + var)
+        logging.info("read_gridded_eos:" + var)
         data = np.array(hdf_read(f, var), dtype=float)
         data = np.flip(data, axis=0)
-        data[data==var_dict[var]['fillvalue']] = np.nan
-        data *= var_dict[var]['scale']
+        data[data == var_dict[var]["fillvalue"]] = np.nan
+        data *= var_dict[var]["scale"]
         var_da = xr.DataArray(
-            data, coords=[lat_da, lon_da],
-            dims=['lat', 'lon'],
-            attrs={'units': var_dict[var]['units']})
+            data,
+            coords=[lat_da, lon_da],
+            dims=["lat", "lon"],
+            attrs={"units": var_dict[var]["units"]},
+        )
         ds_dict[var] = var_da
 
     hdf_close(f)
@@ -55,9 +54,8 @@ def read_gridded_eos(fname, var_dict, save_as_netcdf=False):
     ds = xr.Dataset(ds_dict)
 
     if save_as_netcdf:
-        fname_nc = fname.replace('.hdf', '.nc')
-        logging.info('writing ' + fname_nc)
+        fname_nc = fname.replace(".hdf", ".nc")
+        logging.info("writing " + fname_nc)
         ds.to_netcdf(fname_nc)
 
     return ds
-

--- a/monetio/sat/_gridded_eos_mm.py
+++ b/monetio/sat/_gridded_eos_mm.py
@@ -1,0 +1,63 @@
+import logging
+import numpy as np
+import xarray as xr
+
+import monetio
+
+
+def read_gridded_eos(fname, var_dict, save_as_netcdf=False):
+    """
+    Parameters
+    __________
+    fname : str
+        Input file path.
+    var_dict : dict
+        Dictionary of variables to read, along with variable metadata.
+        {varname: {'fillvalue': float, 'scale': float, 'units': str}, ...}
+    save_as_netcdf: bool, default=False
+        Save variables in var_dict in netcdf format.
+
+
+    Returns
+    _______
+    xarray.Dataset
+    """
+
+    from monetio.sat.hdfio import hdf_open, hdf_close, hdf_list, hdf_read
+
+    ds_dict = dict()
+
+    logging.info('read_gridded_eos:' + fname)
+    f = hdf_open(fname)
+    datasets, indices = hdf_list(f)
+
+    lon = hdf_read(f, 'XDim')
+    lat = np.flip(hdf_read(f, 'YDim'))
+    lon_da = xr.DataArray(lon,
+        attrs={'longname': 'longitude', 'units': 'deg East'})
+    lat_da = xr.DataArray(lat,
+        attrs={'longname': 'latitude', 'units': 'deg North'})
+
+    for var in var_dict:
+        logging.info('read_gridded_eos:' + var)
+        data = np.array(hdf_read(f, var), dtype=float)
+        data = np.flip(data, axis=0)
+        data[data==var_dict[var]['fillvalue']] = np.nan
+        data *= var_dict[var]['scale']
+        var_da = xr.DataArray(
+            data, coords=[lat_da, lon_da],
+            dims=['lat', 'lon'],
+            attrs={'units': var_dict[var]['units']})
+        ds_dict[var] = var_da
+
+    hdf_close(f)
+
+    ds = xr.Dataset(ds_dict)
+
+    if save_as_netcdf:
+        fname_nc = fname.replace('.hdf', '.nc')
+        logging.info('writing ' + fname_nc)
+        ds.to_netcdf(fname_nc)
+
+    return ds
+

--- a/monetio/sat/_gridded_eos_mm.py
+++ b/monetio/sat/_gridded_eos_mm.py
@@ -24,9 +24,11 @@ def read_gridded_eos(fname, var_dict, save_as_netcdf=False):
 
     from monetio.sat.hdfio import hdf_close, hdf_list, hdf_open, hdf_read
 
+    logger = logging.getLogger(__name__)
+
     ds_dict = dict()
 
-    logging.info("read_gridded_eos:" + fname)
+    logger.info("read_gridded_eos:" + fname)
     f = hdf_open(fname)
     datasets, indices = hdf_list(f)
 
@@ -36,7 +38,7 @@ def read_gridded_eos(fname, var_dict, save_as_netcdf=False):
     lat_da = xr.DataArray(lat, attrs={"longname": "latitude", "units": "deg North"})
 
     for var in var_dict:
-        logging.info("read_gridded_eos:" + var)
+        logger.info("read_gridded_eos:" + var)
         data = np.array(hdf_read(f, var), dtype=float)
         data = np.flip(data, axis=0)
         data[data == var_dict[var]["fillvalue"]] = np.nan
@@ -55,7 +57,7 @@ def read_gridded_eos(fname, var_dict, save_as_netcdf=False):
 
     if save_as_netcdf:
         fname_nc = fname.replace(".hdf", ".nc")
-        logging.info("writing " + fname_nc)
+        logger.info("writing " + fname_nc)
         ds.to_netcdf(fname_nc)
 
     return ds


### PR DESCRIPTION
Initial reader for gridded NASA EOS datasets, which include MODIS level 3 products.
Uses monetio.sat.hdfio.
Similar to monetio/sat/_modis_l2_mm.py.