### PR TITLE
Fix WRF-Chem reader to work with latest xarray

### DIFF
--- a/monetio/models/_rrfs_cmaq_mm.py
+++ b/monetio/models/_rrfs_cmaq_mm.py
@@ -200,7 +200,7 @@ def open_mfdataset(
         dset["alt_msl_m_full"] = _calc_hgt(dset)
 
     # Set coordinates
-    dset = dset.reset_index(
+    dset = dset.reset_coords(
         ["x", "y", "z", "z_i"], drop=True
     )  # For now drop z_i no variables use it.
     dset["latitude"] = dset["latitude"].isel(time=0)

--- a/monetio/models/_wrfchem_mm.py
+++ b/monetio/models/_wrfchem_mm.py
@@ -189,7 +189,7 @@ def open_mfdataset(
     if "pm25_om" in list_calc_sum:
         dset = add_lazy_om_pm25(dset, dict_sum)
 
-    dset = dset.reset_index(["XTIME", "datetime"], drop=True)
+    dset = dset.reset_coords(["XTIME", "datetime"], drop=True)
     if not surf_only_nc:
         # Reset more variables
         dset = dset.rename(


### PR DESCRIPTION
Update WRF-Chem reader to be compatible with latest version of xarray.

This fixes this bug here where this reader no longer works properly with the latest versions of xarray:
https://github.com/NOAA-CSL/MELODIES-MONET/issues/149
