### PR TITLE
Fix pardump reading on some platforms

### DIFF
--- a/monetio/models/pardump.py
+++ b/monetio/models/pardump.py
@@ -52,8 +52,8 @@ class Pardump:
         self.fname = fname
         # self.dtfmt = "%Y%m%d%H%M"
 
-        tp1 = ">f"  # big endian float.
-        tp2 = ">i"  # big endian integer.
+        tp1 = ">f4"  # big endian float.
+        tp2 = ">i4"  # big endian integer.
         tp3 = ">i8"  # big endian long integer.
 
         # header record in fortran file.
@@ -144,7 +144,7 @@ class Pardump:
             hdr["minute"] = sdate.minute
             print(hdr)
 
-            endrec = np.array([20], dtype=">i")
+            endrec = np.array([20], dtype=">i4")
 
             fpoint.write(hdr)
             fpoint.write(a)
@@ -202,7 +202,7 @@ class Pardump:
                 data = np.fromfile(fpoint, dtype=self.pardt, count=parnum[0])
                 # n = parnum - 1
                 # padding at end of each record
-                np.fromfile(fpoint, dtype=">i", count=1)
+                np.fromfile(fpoint, dtype=">i4", count=1)
                 if verbose:
                     print("Date ", pdate, " **** ", drange)
 

--- a/monetio/models/pardump.py
+++ b/monetio/models/pardump.py
@@ -54,6 +54,7 @@ class Pardump:
 
         tp1 = ">f"  # big endian float.
         tp2 = ">i"  # big endian integer.
+        tp3 = ">i8"  # big endian long integer.
 
         # header record in fortran file.
         self.hdr_dt = np.dtype(
@@ -75,14 +76,14 @@ class Pardump:
                 ("p1", tp2),
                 ("p2", tp2),
                 ("pmass", tp1),
-                ("p3", ">l"),
+                ("p3", tp3),
                 ("lat", tp1),
                 ("lon", tp1),
                 ("ht", tp1),
                 ("su", tp1),
                 ("sv", tp1),
                 ("sx", tp1),
-                ("p4", ">l"),
+                ("p4", tp3),
                 ("age", tp2),
                 ("dist", tp2),
                 ("poll", tp2),


### PR DESCRIPTION
Resolves #99 

In our testing, the issue seems to be that on Windows, dtype `'>l'` (l as in long) resolves to `'>i4'`, but it is supposed to be `'>i8'` for this file format. On Linux, don't have this issue.