### PR TITLE
Fix OpenAQ reader

### DIFF
--- a/monetio/obs/openaq.py
+++ b/monetio/obs/openaq.py
@@ -199,10 +199,13 @@ class OPENAQ:
                 o3="o3_ppm",
                 no2="no2_ppm",
                 so2="so2_ppm",
+                ch4="ch4_ppm",
+                no="no_ppm",
                 bc="bc_umg3",
                 pm25="pm25_ugm3",
                 pm10="pm10_ugm3",
             ),
             axis=1,
+            errors="ignore",
         )
         return w

--- a/monetio/obs/openaq.py
+++ b/monetio/obs/openaq.py
@@ -101,7 +101,7 @@ class OPENAQ:
         dff.rename({"local": "time_local", "utc": "time"}, axis=1, inplace=True)
 
         dff["time"] = pd.to_datetime(dff.time)
-        dff["time_local"] = pd.to_datetime(dff.time_local)
+        dff["utcoffset"] = pd.to_datetime(dff.time_local).apply(lambda x: x.utcoffset())
         zzz = z.join(dff).drop(columns=["coordinates", "date", "attribution", "averagingPeriod"])
         zp = self._pivot_table(zzz)
         zp["siteid"] = (
@@ -114,8 +114,8 @@ class OPENAQ:
         )
 
         zp["time"] = zp.time.dt.tz_localize(None)
-        tzinfo = zp.time_local.apply(lambda x: x.tzinfo.utcoffset(x))
-        zp["time_local"] = zp["time"] + tzinfo
+        zp["time_local"] = zp["time"] + zp["utcoffset"]
+
         return zp.loc[zp.time >= dates.min()]
 
     def read_json(self, url):
@@ -178,7 +178,7 @@ class OPENAQ:
                 "sourceType",
                 "city",
                 "country",
-                "time_local",
+                "utcoffset",
             ],
             columns="parameter",
         ).reset_index()

--- a/monetio/obs/openaq.py
+++ b/monetio/obs/openaq.py
@@ -173,9 +173,9 @@ class OPENAQ:
         # rounded to 3 significant figures.
         fs = {"co": 1160, "o3": 1990, "so2": 2650, "no2": 1900, "ch4": 664, "no": 1240}
         for vn, f in fs.items():
-            df.loc[(df.parameter == vn) & (df.unit == "µg/m³"), "value"] /= f
-        for vn in fs:
-            df.loc[(df.parameter == vn) & (df.unit == "µg/m³"), "unit"] = "ppm"
+            is_ug = (df.parameter == vn) & (df.unit == "µg/m³")
+            df.loc[is_ug, "value"] /= f
+            df.loc[is_ug, "unit"] = "ppm"
         return df
 
     def _pivot_table(self, df):

--- a/monetio/obs/openaq.py
+++ b/monetio/obs/openaq.py
@@ -165,13 +165,16 @@ class OPENAQ:
 
     def _fix_units(self, df):
         df.loc[df.value <= 0] = NaN
-        # TODO: all unique params just to be safe? (need conversion factors)
+        # For a certain parameter, different site-times may have different units.
         # https://docs.openaq.org/docs/parameters
-        df.loc[(df.parameter == "co") & (df.unit == "µg/m³"), "value"] /= 1145
-        df.loc[(df.parameter == "o3") & (df.unit == "µg/m³"), "value"] /= 2000
-        df.loc[(df.parameter == "so2") & (df.unit == "µg/m³"), "value"] /= 2620
-        df.loc[(df.parameter == "no2") & (df.unit == "µg/m³"), "value"] /= 1880
-        for vn in ["co", "o3", "so2", "no2"]:
+        # These conversion factors are based on
+        # - air average molecular weight: 29 g/mol
+        # - air density: 1.2 kg m -3
+        # rounded to 3 significant figures.
+        fs = {"co": 1160, "o3": 1990, "so2": 2650, "no2": 1900, "ch4": 664, "no": 1240}
+        for vn, f in fs.items():
+            df.loc[(df.parameter == vn) & (df.unit == "µg/m³"), "value"] /= f
+        for vn in fs:
             df.loc[(df.parameter == vn) & (df.unit == "µg/m³"), "unit"] = "ppm"
         return df
 

--- a/tests/test_openaq.py
+++ b/tests/test_openaq.py
@@ -1,0 +1,13 @@
+import pandas as pd
+
+from monetio import openaq
+
+
+def test_openaq():
+    # First date in the archive, just one file
+    # Browse the archive at https://openaq-fetches.s3.amazonaws.com/index.html
+    dates = pd.date_range(start="2013-11-26", end="2013-11-27", freq="H")[:-1]
+    df = openaq.add_data(dates)
+    assert not df.empty
+    assert df.siteid.nunique() == 1
+    assert (df.country == "CN").all() and ((df.time_local - df.time) == pd.Timedelta(hours=8)).all()

--- a/tests/test_openaq.py
+++ b/tests/test_openaq.py
@@ -1,8 +1,12 @@
+import sys
+
 import pandas as pd
+import pytest
 
 from monetio import openaq
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python 3.7+")
 def test_openaq():
     # First date in the archive, just one file
     # Browse the archive at https://openaq-fetches.s3.amazonaws.com/index.html


### PR DESCRIPTION
* local time calc
  - don't quite understand *why* it wasn't working properly (giving only a few unique UTC offsets), but looks more reasonable now (several unique UTC offsets and correct e.g. most common is +8 UTC which mostly corresponds to sites in China)
* convert to ppmv
  - there was code to do so but it wasn't being used
  - updated and documented the conversion factors and added factors for CH4 and NO which [can be](https://docs.openaq.org/docs/parameters) in OpenAQ data

* [x] at least one test (maybe find a way to set things to load just one file for testing)