### PR TITLE
Tweak AirNow UTC offset test

### DIFF
--- a/.codespell-exclude
+++ b/.codespell-exclude
@@ -35,3 +35,5 @@
     df = aeronet.add_data(dates, inv_type="ALM15", product="SIZ")
     df = aeronet.add_data(dates, inv_type="HYB15", product="SIZ")
     # https://aeronet.gsfc.nasa.gov/cgi-bin/print_web_data_inv_v3?site=Cart_Site&year=2002&month=6&day=1&year2=2003&month2=6&day2=14&product=SIZ&AVG=20&ALM15=1&if_no_html=1
+   "RIN",	"Refractive indices (real and imaginary)"
+        "RIN",


### PR DESCRIPTION
Recently, "yesterday" usually has no bad sites (but not always). With this update, the "yesterday" case is allowed to go either way (so it doesn't fail CI), while two recent fixed-date cases are added. This should make CI overall less flaky.