### PR TITLE
ICARTT: support non-whole-number data interval, apply scaling factor

### DIFF
--- a/monetio/profile/icartt.py
+++ b/monetio/profile/icartt.py
@@ -341,7 +341,7 @@ class Dataset:
         # value is set to 0. The Mid-point time is required when it is not at the
         # average of Start and Stop times. For additional information see Section
         # 2.5 below.).
-        self.dataInterval = int(self.__readline()[0])
+        self.dataInterval = float(self.__readline()[0])
 
         # line 9 - Description or name of independent variable (This is the name
         # chosen for the start time. It always refers to the number of seconds UTC
@@ -436,7 +436,7 @@ class Dataset:
             v = x.replace(self.VAR[i].miss, "NaN")
             if "NaN" in v:
                 v = "NaN"
-            vals.append(float(v.strip()))
+            vals.append(float(v.strip())*self.VAR[i].scale)  # multiply with scaling factor
         return vals
 
     def read_data(self):

--- a/monetio/profile/icartt.py
+++ b/monetio/profile/icartt.py
@@ -436,7 +436,7 @@ class Dataset:
             v = x.replace(self.VAR[i].miss, "NaN")
             if "NaN" in v:
                 v = "NaN"
-            vals.append(float(v.strip())*self.VAR[i].scale)  # multiply with scaling factor
+            vals.append(float(v.strip()) * self.VAR[i].scale)  # multiply with scaling factor
         return vals
 
     def read_data(self):


### PR DESCRIPTION
Fixed the bug that does not consider the ICARTT's scaling factors and  datainterval in float-point time.