### PR TITLE
fix lat and lon in _cesm_fv_reader

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -20,6 +20,7 @@ dependencies:
   - joblib
   - lxml
   - pyhdf!=0.11.3
+  - pyresample
   - requests
   - timezonefinder
   #

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -101,7 +101,7 @@ def open_mfdataset(
     # re-order so surface is associated with the first vertical index
     dset = dset.sortby("z", ascending=False)
 
-    # Get rid of variables lat and lon to avoid future conflicts
+    # Get rid of original 1-D lat and lon to avoid future conflicts
     dset = dset.drop_vars(["lat", "lon"])
 
     #############################

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -92,8 +92,8 @@ def open_mfdataset(
     lon = wrap_longitudes(dset["lon"])
     lat = dset["lat"]
     lons, lats = meshgrid(lon, lat)
-    dset.coords["longitude"] = (("y", "x"), lons)
-    dset.coords["latitude"] = (("y", "x"), lats)
+    dset["longitude"] = (("y", "x"), lons)
+    dset["latitude"] = (("y", "x"), lats)
 
     # Set longitude and latitude to be only coordinates
     dset = dset.reset_coords()

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -69,7 +69,7 @@ def open_mfdataset(
             }
         )
         # Calc height agl. PHIS is in m2/s2, whereas Z3 is in already in m
-        dset_load["alt_agl_m_mid"] = dset_load["alt_msl_m_mid"] - dset_load["PHIS"] / 9.81
+        dset_load["alt_agl_m_mid"] = dset_load["alt_msl_m_mid"] - dset_load["PHIS"] / 9.80665
         dset_load["alt_agl_m_mid"].attrs = {
             "description": "geopotential height above ground level",
             "units": "m",

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -2,7 +2,7 @@
 
 import xarray as xr
 from numpy import meshgrid
-import warning
+import warnings
 
 
 def open_mfdataset(

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -139,9 +139,11 @@ def open_mfdataset(
 
 def _ensure_mfdataset_filenames(fname):
     """Checks if dataset in netcdf format
+
     Parameters
     ----------
     fname : string or list of strings
+
     Returns
     -------
     type
@@ -163,9 +165,11 @@ def _ensure_mfdataset_filenames(fname):
 
 def _calc_pressure(dset):
     """Calculates midlayer pressure using P0, PS, hyam, hybm
+
     Parameters
     ----------
     dset: xr.Dataset
+
     Returns
     -------
     xr.DataArray
@@ -210,9 +214,11 @@ def _calc_pressure(dset):
 
 def _calc_hydrostatic_height(dset):
     """Calculates midlayer height using PMID, P, PS and PHIS, T,
+
     Parameters
     ----------
     dset: xr.Dataset
+
     Returns
     -------
     xr.DataArray

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -188,7 +188,7 @@ def _calc_pressure(dset):
     pressure = np.zeros((n_time, n_vert, n_lat, n_lon))
 
     if "P0" not in dset.keys():
-        warning.warn("P0 not in netcdf keys, assuming 100_000 Pa")
+        warnings.warn("P0 not in netcdf keys, assuming 100_000 Pa")
         p0 = 100_000
     else:
         p0 = dset["P0"].values

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -59,7 +59,6 @@ def open_mfdataset(
     # Process the loaded data
     # extract variables of choice
     # If vertical information is required, add it.
-    # Assume that height and geopotential height are equal
     if not surf_only:
         dset_load.rename(
             {

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -38,9 +38,14 @@ def open_mfdataset(
     Returns
     -------
     xarray.DataSet
-
-
     """
+
+    if not surf_only:
+        warnings.warn(
+            "3D data processing is still experimental in CESM-Fv (CAM-Chem), "
+            + "and has not been properly tested. Use at own risk."
+        )
+
     from pyresample.utils import wrap_longitudes
 
     # check that the files are netcdf format

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -37,12 +37,12 @@ def open_mfdataset(
 
     Returns
     -------
-    xarray.DataSet
+    xarray.Dataset
     """
 
     if not surf_only:
         warnings.warn(
-            "3D data processing is still experimental in CESM-Fv (CAM-Chem), "
+            "3D data processing is still experimental in CESM-FV (CAM-Chem), "
             + "and has not been properly tested. Use at own risk."
         )
 

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -72,7 +72,7 @@ def open_mfdataset(
         # Calc height agl. PHIS is in m2/s2, whereas Z3 is in already in m
         dset_load["alt_agl_m_mid"] = dset_load["alt_msl_m_mid"] - dset_load["PHIS"] / 9.81
         dset_load["alt_agl_m_mid"].attrs = {
-            "description": "geopot height above ground level",
+            "description": "geopotential height above ground level",
             "units": "m",
         }
         var_list = var_list + [

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -243,9 +243,9 @@ def _calc_hydrostatic_height(dset):
     for nlev in range(n_vert - 1, -1, -1):
         height_b = height[:, nlev + 1, :, :]
         temp_b = dset["T"].isel(lev=nlev + 1).values
-        pres_b = dset["PMID"].isel(lev=nlev + 1)
-        pres = dset["PMID"].isel(lev=nlev)
-        height[:, nlev, :, :] = height_b - R * temp_b * np.ln(pres / pres_b) / (GRAVITY * M_AIR)
+        press_b = dset["PMID"].isel(lev=nlev + 1)
+        press = dset["PMID"].isel(lev=nlev)
+        height[:, nlev, :, :] = height_b - R * temp_b * np.ln(press / press_b) / (GRAVITY * M_AIR)
 
     z = xr.DataArray(
         data=height,

--- a/tests/test_cesm_fv.py
+++ b/tests/test_cesm_fv.py
@@ -32,7 +32,7 @@ def retrieve_test_file():
     return p
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def test_file_path(tmp_path_factory, worker_id):
     if worker_id == "master":
         # Not executing with multiple workers;

--- a/tests/test_cesm_fv.py
+++ b/tests/test_cesm_fv.py
@@ -3,6 +3,7 @@ import warnings
 from pathlib import Path
 
 import pandas as pd
+import numpy as np
 import pytest
 from filelock import FileLock
 
@@ -29,7 +30,7 @@ def retrieve_test_file():
         with open(p, "wb") as f:
             f.write(r.content)
 
-    return p
+    return str(p)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_cesm_fv.py
+++ b/tests/test_cesm_fv.py
@@ -57,8 +57,8 @@ def _test_ds(ds):
     assert set(ds.dims) == {"time", "x", "y", "z"}
 
     # Test coordinates
-    assert "lat" not in ds.data_vars
-    assert "lon" not in ds.data_vars
+    assert "lat" not in ds.variables
+    assert "lon" not in ds.variables
     assert "latitude" in ds.coords
     assert "longitude" in ds.coords
     assert np.all(ds.latitude.values[0, :] == ds.latitude.values[0, 0])

--- a/tests/test_cesm_fv.py
+++ b/tests/test_cesm_fv.py
@@ -29,7 +29,7 @@ def retrieve_test_file():
         with open(p, "wb") as f:
             f.write(r.content)
 
-    return str(p)
+    return p
 
 
 @pytest.fixture(scope="module")
@@ -68,5 +68,6 @@ def _test_ds(ds):
 
 
 def test_open_mfdataset(test_file_path):
-    ds = open_mfdataset(test_file_path)
+    file_path = str(test_file_path)
+    ds = open_mfdataset(file_path)
     _test_ds(ds)

--- a/tests/test_cesm_fv.py
+++ b/tests/test_cesm_fv.py
@@ -1,0 +1,71 @@
+import shutil
+import warnings
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from filelock import FileLock
+
+from monetio.sat._tropomi_l2_no2_mm import open_dataset
+
+HERE = Path(__file__).parent
+
+
+def retrieve_test_file():
+    fn = "CAM_chem_merra2_FCSD_1deg_QFED_world_201909-01-09_small_sfc.nc"
+
+    # Download to tests/data if not already present
+    p = HERE / "data" / fn
+    if not p.is_file():
+        warnings.warn(f"Downloading test file {fn} for CESM-FV test")
+        import requests
+
+        r = requests.get(
+            "https://csl.noaa.gov/groups/csl4/modeldata/melodies-monet/data/"
+            + f"example_model_data/cesmfv_example/{fn}",
+            stream=True,
+        )
+        r.raise_for_status()
+        with open(p, "wb") as f:
+            f.write(r.content)
+
+    return p
+
+
+@pytest.fixture(scope="session")
+def test_file_path(tmp_path_factory, worker_id):
+    if worker_id == "master":
+        # Not executing with multiple workers;
+        # let pytest's fixture caching do its job
+        return retrieve_test_file()
+
+    # Get the temp directory shared by all workers
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+
+    # Copy to the shared test location
+    p_test = root_tmp_dir / "cesm_fv_tst.nc"
+    with FileLock(p_test.as_posix() + ".lock"):
+        if p_test.is_file():
+            return p_test
+        else:
+            p = retrieve_test_file()
+            shutil.copy(p, p_test)
+            return p_test
+
+
+def _test_ds(ds):
+    assert set(ds.dims) == {"time", "x", "y", "z"}
+
+    # Test coordinates
+    assert "lat" not in ds.data_vars
+    assert "lon" not in ds.data_vars
+    assert "latitude" in ds.coords
+    assert "longitude" in ds.coords
+    assert np.all(ds.latitude.values[0, :] == ds.latitude.values[0,0])
+    assert np.all(ds.longitude.values[:, 0] == ds.longitude.values[0,0])
+    assert tuple(ds["O3"].dims) == ('time', 'z', 'y', 'x')
+    assert ds['O3'].attrs['units'] == 'ppbv'
+
+
+def test_open_mfdataset(test_file_path):
+    ds = _cesm_fv.open_dataset(TEST_FP)

--- a/tests/test_cesm_fv.py
+++ b/tests/test_cesm_fv.py
@@ -43,7 +43,7 @@ def test_file_path(tmp_path_factory, worker_id):
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
 
     # Copy to the shared test location
-    p_test = root_tmp_dir / "cesm_fv_tst.nc"
+    p_test = root_tmp_dir / "cesm_fv_test.nc"
     with FileLock(p_test.as_posix() + ".lock"):
         if p_test.is_file():
             return p_test

--- a/tests/test_cesm_fv.py
+++ b/tests/test_cesm_fv.py
@@ -2,7 +2,6 @@ import shutil
 import warnings
 from pathlib import Path
 
-import pandas as pd
 import numpy as np
 import pytest
 from filelock import FileLock
@@ -62,10 +61,10 @@ def _test_ds(ds):
     assert "lon" not in ds.data_vars
     assert "latitude" in ds.coords
     assert "longitude" in ds.coords
-    assert np.all(ds.latitude.values[0, :] == ds.latitude.values[0,0])
-    assert np.all(ds.longitude.values[:, 0] == ds.longitude.values[0,0])
-    assert tuple(ds["O3"].dims) == ('time', 'z', 'y', 'x')
-    assert ds['O3'].attrs['units'] == 'ppbv'
+    assert np.all(ds.latitude.values[0, :] == ds.latitude.values[0, 0])
+    assert np.all(ds.longitude.values[:, 0] == ds.longitude.values[0, 0])
+    assert tuple(ds["O3"].dims) == ("time", "z", "y", "x")
+    assert ds["O3"].attrs["units"] == "ppbv"
 
 
 def test_open_mfdataset(test_file_path):

--- a/tests/test_cesm_fv.py
+++ b/tests/test_cesm_fv.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from filelock import FileLock
 
-from monetio.sat._tropomi_l2_no2_mm import open_dataset
+from monetio.models._cesm_fv_mm import open_mfdataset
 
 HERE = Path(__file__).parent
 

--- a/tests/test_cesm_fv.py
+++ b/tests/test_cesm_fv.py
@@ -68,4 +68,5 @@ def _test_ds(ds):
 
 
 def test_open_mfdataset(test_file_path):
-    ds = _cesm_fv.open_dataset(TEST_FP)
+    ds = open_mfdataset(test_file_path)
+    _test_ds(ds)


### PR DESCRIPTION
Correct _cesm_fv_mm.py reader for good functionality with MELODIES-MONET

	Delete variables to avoid duplication in melodies-monet
	Add (optional) variables for vertical coordinates:
		temperature_k
		alt_msl_m_mid
		alt_agl_m_mid
		surfpres_pa
		pres_pa_mid

PS: Sorry for submitting 2 PRs on the same day, these are what I had finished and had not submitted yet. I think that they should be tested separately.

xref: https://github.com/NOAA-CSL/MELODIES-MONET/issues/261
