### PR TITLE
Reduce warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
             attrs=22.2.0
 
       - name: Test with pytest
-        run: pytest -n auto -v
+        run: pytest -n auto -v -W "ignore:Downloading test file:UserWarning::"
 
       - name: Test with pytspack installed
         run: |

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,3 +31,4 @@ dependencies:
   - pip>=21.1
   - pip:
       - "-e ."
+      - pytest-print

--- a/monetio/profile/geoms.py
+++ b/monetio/profile/geoms.py
@@ -110,7 +110,7 @@ def open_dataset(fp, *, rename_all=True, squeeze=True):
         n = ds[ref].size
         time_dims = [
             dim_name
-            for dim_name, dim_size in ds.dims.items()
+            for dim_name, dim_size in ds.sizes.items()
             if dim_name.startswith("fakeDim") and dim_size == n
         ]
         ds = ds.rename_dims({dim_name: new_dim for dim_name in time_dims})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,5 @@ filterwarnings = [
     "ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning::",
     "ignore:The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.:FutureWarning::",
     "ignore:np.find_common_type is deprecated.:DeprecationWarning:pandas:",
-    "ignore:The current Dask DataFrame implementation is deprecated.:DeprecationWarning:dask.dataframe:",
+    "ignore:The current Dask DataFrame implementation is deprecated.:DeprecationWarning:dask:",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,5 @@ filterwarnings = [
     "ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning::",
     "ignore:The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.:FutureWarning::",
     "ignore:np.find_common_type is deprecated.:DeprecationWarning:pandas:",
-    "ignore:The current Dask DataFrame implementation is deprecated.:DeprecationWarning:dask:",
+    "ignore:The current Dask DataFrame implementation is deprecated.:DeprecationWarning::",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,5 @@ filterwarnings = [
     "ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning::",
     "ignore:The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.:FutureWarning::",
     "ignore:np.find_common_type is deprecated.:DeprecationWarning:pandas:",
+    "ignore:The current Dask DataFrame implementation is deprecated.:DeprecationWarning:dask.dataframe:",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,6 @@ filterwarnings = [
     "ignore:The NPY_CHAR type_num is deprecated. Please port your code to use NPY_STRING instead.:DeprecationWarning::",
     "ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning::",
     "ignore:The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.:FutureWarning::",
-    "ignore:np.find_common_type is deprecated.:DeprecationWarning:pandas:",
+    "ignore:np.find_common_type is deprecated.:DeprecationWarning::",
     "ignore:The current Dask DataFrame implementation is deprecated.:DeprecationWarning::",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def is_ci():
+    return os.environ.get("CI", "false").lower() == "true"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,4 +5,4 @@ import pytest
 
 @pytest.fixture(scope="session")
 def is_ci():
-    return os.environ.get("CI", "false").lower() == "true"
+    return os.environ.get("CI", "false").lower() in {"true", "yes", "1", ""}

--- a/tests/test_airnow.py
+++ b/tests/test_airnow.py
@@ -73,7 +73,7 @@ def test_add_data_daily():
         "yesterday",  # varies
     ],
 )
-def test_check_zero_utc_offsets(date, bad_utcoffset, request):
+def test_check_zero_utc_offsets(date, bad_utcoffset, request, is_ci):
     dates = [date]
 
     case = request.node.callspec.id.split("-")[0]
@@ -96,7 +96,8 @@ def test_check_zero_utc_offsets(date, bad_utcoffset, request):
                 f"{len(bad_sites)} sites with zero UTC offset and abs(lon) > 20:\n"
             )
             msg += bad_sites.to_string(index=False)
-            warnings.warn(msg)
+            if not is_ci:
+                warnings.warn(msg)
     elif bad_utcoffset == "null":
         if case in {"multiple_bad", "some_bad"}:
             assert df.utcoffset.isnull().sum() > 0

--- a/tests/test_airnow.py
+++ b/tests/test_airnow.py
@@ -1,5 +1,3 @@
-import warnings
-
 import pandas as pd
 import pytest
 
@@ -73,7 +71,7 @@ def test_add_data_daily():
         "yesterday",  # varies
     ],
 )
-def test_check_zero_utc_offsets(date, bad_utcoffset, request, is_ci):
+def test_check_zero_utc_offsets(date, bad_utcoffset, request, printer):
     dates = [date]
 
     case = request.node.callspec.id.split("-")[0]
@@ -96,8 +94,7 @@ def test_check_zero_utc_offsets(date, bad_utcoffset, request, is_ci):
                 f"{len(bad_sites)} sites with zero UTC offset and abs(lon) > 20:\n"
             )
             msg += bad_sites.to_string(index=False)
-            if not is_ci:
-                warnings.warn(msg)
+            printer(msg)
     elif bad_utcoffset == "null":
         if case in {"multiple_bad", "some_bad"}:
             assert df.utcoffset.isnull().sum() > 0

--- a/tests/test_geoms.py
+++ b/tests/test_geoms.py
@@ -21,19 +21,19 @@ def test_open():
     ds = geoms.open_dataset(TEST_FP)
     assert "o3_mixing_ratio_volume_derived" in ds.variables
     assert tuple(ds["o3_mixing_ratio_volume_derived"].dims) == ("time", "altitude")
-    assert ds.dims == {"time": 28, "altitude": 496}
+    assert ds.sizes == {"time": 28, "altitude": 496}
 
 
 def test_open_no_rename_vars():
     ds = geoms.open_dataset(TEST_FP, rename_all=False)
     assert "O3.MIXING.RATIO.VOLUME_DERIVED" in ds.variables
     assert tuple(ds["O3.MIXING.RATIO.VOLUME_DERIVED"].dims) == ("time", "altitude")
-    assert ds.dims == {"time": 28, "altitude": 496}
+    assert ds.sizes == {"time": 28, "altitude": 496}
 
 
 def test_open_no_squeeze():
     ds = geoms.open_dataset(TEST_FP, squeeze=False)
-    assert ds.dims == {
+    assert ds.sizes == {
         "latitude": 1,
         "longitude": 1,
         "altitude_instrument": 1,

--- a/tests/test_mopitt_l3.py
+++ b/tests/test_mopitt_l3.py
@@ -34,7 +34,7 @@ def retrieve_test_file(is_ci=False):
 
 
 @pytest.fixture(scope="module")
-def test_file_path(tmp_path_factory, worker_id):
+def test_file_path(tmp_path_factory, worker_id, is_ci):
     if worker_id == "master":
         # Not executing with multiple workers;
         # let pytest's fixture caching do its job
@@ -49,7 +49,7 @@ def test_file_path(tmp_path_factory, worker_id):
         if p_test.is_file():
             return p_test
         else:
-            p = retrieve_test_file()
+            p = retrieve_test_file(is_ci=is_ci)
             shutil.copy(p, p_test)
             return p_test
 

--- a/tests/test_mopitt_l3.py
+++ b/tests/test_mopitt_l3.py
@@ -11,14 +11,13 @@ from monetio.sat._mopitt_l3_mm import get_start_time, load_variable, open_datase
 HERE = Path(__file__).parent
 
 
-def retrieve_test_file(is_ci=False):
+def retrieve_test_file():
     fn = "MOP03JM-201701-L3V95.9.3.he5"
 
     # Download to tests/data if not already present
     p = HERE / "data" / fn
     if not p.is_file():
-        if not is_ci:
-            warnings.warn(f"Downloading test file {fn} for MOPITT L3 test")
+        warnings.warn(f"Downloading test file {fn} for MOPITT L3 test")
         import requests
 
         r = requests.get(
@@ -34,7 +33,7 @@ def retrieve_test_file(is_ci=False):
 
 
 @pytest.fixture(scope="module")
-def test_file_path(tmp_path_factory, worker_id, is_ci):
+def test_file_path(tmp_path_factory, worker_id):
     if worker_id == "master":
         # Not executing with multiple workers;
         # let pytest's fixture caching do its job
@@ -49,7 +48,7 @@ def test_file_path(tmp_path_factory, worker_id, is_ci):
         if p_test.is_file():
             return p_test
         else:
-            p = retrieve_test_file(is_ci=is_ci)
+            p = retrieve_test_file()
             shutil.copy(p, p_test)
             return p_test
 

--- a/tests/test_mopitt_l3.py
+++ b/tests/test_mopitt_l3.py
@@ -11,13 +11,14 @@ from monetio.sat._mopitt_l3_mm import get_start_time, load_variable, open_datase
 HERE = Path(__file__).parent
 
 
-def retrieve_test_file():
+def retrieve_test_file(is_ci=False):
     fn = "MOP03JM-201701-L3V95.9.3.he5"
 
     # Download to tests/data if not already present
     p = HERE / "data" / fn
     if not p.is_file():
-        warnings.warn(f"Downloading test file {fn} for MOPITT L3 test")
+        if not is_ci:
+            warnings.warn(f"Downloading test file {fn} for MOPITT L3 test")
         import requests
 
         r = requests.get(

--- a/tests/test_mopitt_l3.py
+++ b/tests/test_mopitt_l3.py
@@ -33,7 +33,7 @@ def retrieve_test_file(is_ci=False):
     return p
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def test_file_path(tmp_path_factory, worker_id):
     if worker_id == "master":
         # Not executing with multiple workers;

--- a/tests/test_omps_l3.py
+++ b/tests/test_omps_l3.py
@@ -38,7 +38,7 @@ def retrieve_test_file(i, is_ci=False):
     return p
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def test_file_paths(tmp_path_factory, worker_id):
     if worker_id == "master":
         # Not executing with multiple workers;

--- a/tests/test_omps_l3.py
+++ b/tests/test_omps_l3.py
@@ -16,13 +16,14 @@ FNS = [
 ]
 
 
-def retrieve_test_file(i):
+def retrieve_test_file(i, is_ci=False):
     fn = FNS[i]
 
     # Download to tests/data if not already present
     p = HERE / "data" / fn
     if not p.is_file():
-        warnings.warn(f"Downloading test file {fn} for OMPS L3 test")
+        if not is_ci:
+            warnings.warn(f"Downloading test file {fn} for OMPS L3 test")
         import requests
 
         r = requests.get(

--- a/tests/test_omps_l3.py
+++ b/tests/test_omps_l3.py
@@ -39,7 +39,7 @@ def retrieve_test_file(i, is_ci=False):
 
 
 @pytest.fixture(scope="module")
-def test_file_paths(tmp_path_factory, worker_id):
+def test_file_paths(tmp_path_factory, worker_id, is_ci):
     if worker_id == "master":
         # Not executing with multiple workers;
         # let pytest's fixture caching do its job
@@ -54,7 +54,7 @@ def test_file_paths(tmp_path_factory, worker_id):
         p_test = root_tmp_dir / f"omps_l3_test_{i}.he5"
         with FileLock(p_test.as_posix() + ".lock"):
             if not p_test.is_file():
-                p = retrieve_test_file(i)
+                p = retrieve_test_file(i, is_ci=is_ci)
                 shutil.copy(p, p_test)
             p_tests.append(p_test)
 

--- a/tests/test_omps_l3.py
+++ b/tests/test_omps_l3.py
@@ -16,14 +16,13 @@ FNS = [
 ]
 
 
-def retrieve_test_file(i, is_ci=False):
+def retrieve_test_file(i):
     fn = FNS[i]
 
     # Download to tests/data if not already present
     p = HERE / "data" / fn
     if not p.is_file():
-        if not is_ci:
-            warnings.warn(f"Downloading test file {fn} for OMPS L3 test")
+        warnings.warn(f"Downloading test file {fn} for OMPS L3 test")
         import requests
 
         r = requests.get(
@@ -39,7 +38,7 @@ def retrieve_test_file(i, is_ci=False):
 
 
 @pytest.fixture(scope="module")
-def test_file_paths(tmp_path_factory, worker_id, is_ci):
+def test_file_paths(tmp_path_factory, worker_id):
     if worker_id == "master":
         # Not executing with multiple workers;
         # let pytest's fixture caching do its job
@@ -54,7 +53,7 @@ def test_file_paths(tmp_path_factory, worker_id, is_ci):
         p_test = root_tmp_dir / f"omps_l3_test_{i}.he5"
         with FileLock(p_test.as_posix() + ".lock"):
             if not p_test.is_file():
-                p = retrieve_test_file(i, is_ci=is_ci)
+                p = retrieve_test_file(i)
                 shutil.copy(p, p_test)
             p_tests.append(p_test)
 

--- a/tests/test_tropomi_l2.py
+++ b/tests/test_tropomi_l2.py
@@ -34,7 +34,7 @@ def retrieve_test_file(is_ci=False):
 
 
 @pytest.fixture(scope="module")
-def test_file_path(tmp_path_factory, worker_id):
+def test_file_path(tmp_path_factory, worker_id, is_ci):
     if worker_id == "master":
         # Not executing with multiple workers;
         # let pytest's fixture caching do its job
@@ -49,7 +49,7 @@ def test_file_path(tmp_path_factory, worker_id):
         if p_test.is_file():
             return p_test
         else:
-            p = retrieve_test_file()
+            p = retrieve_test_file(is_ci=is_ci)
             shutil.copy(p, p_test)
             return p_test
 

--- a/tests/test_tropomi_l2.py
+++ b/tests/test_tropomi_l2.py
@@ -11,14 +11,13 @@ from monetio.sat._tropomi_l2_no2_mm import open_dataset
 HERE = Path(__file__).parent
 
 
-def retrieve_test_file(is_ci=False):
+def retrieve_test_file():
     fn = "TROPOMI-L2-NO2-20190715.nc"
 
     # Download to tests/data if not already present
     p = HERE / "data" / fn
     if not p.is_file():
-        if not is_ci:
-            warnings.warn(f"Downloading test file {fn} for TROPOMI L2 test")
+        warnings.warn(f"Downloading test file {fn} for TROPOMI L2 test")
         import requests
 
         r = requests.get(
@@ -34,7 +33,7 @@ def retrieve_test_file(is_ci=False):
 
 
 @pytest.fixture(scope="module")
-def test_file_path(tmp_path_factory, worker_id, is_ci):
+def test_file_path(tmp_path_factory, worker_id):
     if worker_id == "master":
         # Not executing with multiple workers;
         # let pytest's fixture caching do its job
@@ -49,7 +48,7 @@ def test_file_path(tmp_path_factory, worker_id, is_ci):
         if p_test.is_file():
             return p_test
         else:
-            p = retrieve_test_file(is_ci=is_ci)
+            p = retrieve_test_file()
             shutil.copy(p, p_test)
             return p_test
 

--- a/tests/test_tropomi_l2.py
+++ b/tests/test_tropomi_l2.py
@@ -33,7 +33,7 @@ def retrieve_test_file(is_ci=False):
     return p
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def test_file_path(tmp_path_factory, worker_id):
     if worker_id == "master":
         # Not executing with multiple workers;

--- a/tests/test_tropomi_l2.py
+++ b/tests/test_tropomi_l2.py
@@ -11,13 +11,14 @@ from monetio.sat._tropomi_l2_no2_mm import open_dataset
 HERE = Path(__file__).parent
 
 
-def retrieve_test_file():
+def retrieve_test_file(is_ci=False):
     fn = "TROPOMI-L2-NO2-20190715.nc"
 
     # Download to tests/data if not already present
     p = HERE / "data" / fn
     if not p.is_file():
-        warnings.warn(f"Downloading test file {fn} for TROPOMI L2 test")
+        if not is_ci:
+            warnings.warn(f"Downloading test file {fn} for TROPOMI L2 test")
         import requests
 
         r = requests.get(


### PR DESCRIPTION
Address some warnings and reduce noise in CI pytest logs a bit (some warnings raised within the tests for info/debug are not needed in CI).