### PR TITLE
Small changes to OMPS nadir mapper level 2 reader

### DIFF
--- a/monetio/sat/_omps_nadir_mm.py
+++ b/monetio/sat/_omps_nadir_mm.py
@@ -37,6 +37,8 @@ def read_OMPS_nm(files):
                 else:
                     data_array = xr.concat([data_array, data], "x")
             except (KeyError, ValueError) as e:
+                # KeyError occurs when file exists but contains no data
+                # ValueError occurs when file cross-track dimensions are different than other files loaded
                 print(f"warning: skipping {filename}. {type(e).__name__} occured: {e}")
     if count == 0:
         raise RuntimeError(f"no files loaded from files={files}")

--- a/monetio/sat/_omps_nadir_mm.py
+++ b/monetio/sat/_omps_nadir_mm.py
@@ -38,6 +38,8 @@ def read_OMPS_nm(files):
                     data_array = xr.concat([data_array, data], "x")
             except (KeyError, ValueError) as e:
                 print(f"warning: skipping {filename}. {type(e).__name__} occured: {e}")
+    if count == 0:
+        raise RuntimeError(f"no files loaded from files={files}")
     return data_array
 
 

--- a/monetio/sat/_omps_nadir_mm.py
+++ b/monetio/sat/_omps_nadir_mm.py
@@ -29,18 +29,23 @@ def read_OMPS_nm(files):
         if isinstance(files,str):
             filelist = sorted(glob(files, recursive=False))
         else: 
-            filelist = files # assume list
+            filelist = sorted(files) # assume list
         for filename in filelist:
             try:
                 data = extract_OMPS_nm(filename)
-
+                #print(data.dims)
                 if count == 0:
                     data_array = data
                     count += 1
                 else:
                     data_array = xr.concat([data_array, data], "x")
-            except KeyError:
+            except KeyError as e:
                 print(f'KeyError occured for: {filename}')
+                print(e)
+            except ValueError as e:
+                print(f'ValueError occured for: {filename}')
+                print(e)
+            #print(data_array.dims)
     return data_array
 
 
@@ -158,4 +163,5 @@ def extract_OMPS_nm(fname):
         },
         attrs={"missing_value": -999},
     )
+    print(ds['time'][0],ds.dims)
     return ds

--- a/monetio/sat/_omps_nadir_mm.py
+++ b/monetio/sat/_omps_nadir_mm.py
@@ -37,8 +37,8 @@ def read_OMPS_nm(files):
                 else:
                     data_array = xr.concat([data_array, data], "x")
             except (KeyError, ValueError) as e:
-                # KeyError occurs when file exists but contains no data
-                # ValueError occurs when file cross-track dimensions are different than other files loaded
+                # KeyError occurs in load when file exists but contains no data
+                # ValueError occurs in concat when file cross-track dimensions are different than other files loaded
                 print(f"warning: skipping {filename}. {type(e).__name__} occured: {e}")
     if count == 0:
         raise RuntimeError(f"no files loaded from files={files}")

--- a/monetio/sat/_omps_nadir_mm.py
+++ b/monetio/sat/_omps_nadir_mm.py
@@ -23,12 +23,12 @@ def read_OMPS_nm(files):
                 count += 1
             else:
                 data_array = xr.concat([data_array, data], "x")
-    else: # using local files
-        if isinstance(files,str): # expansion of filestring to list
+    else:  # using local files
+        if isinstance(files, str):  # expansion of filestring to list
             filelist = sorted(glob(files, recursive=False))
-        else: # ensure provided filelist is sorted
-            filelist = sorted(files) # assume list
-        for filename in filelist: #extract data
+        else:  # ensure provided filelist is sorted
+            filelist = sorted(files)  # assume list
+        for filename in filelist:  # extract data
             try:
                 data = extract_OMPS_nm(filename)
                 if count == 0:

--- a/monetio/sat/_omps_nadir_mm.py
+++ b/monetio/sat/_omps_nadir_mm.py
@@ -39,7 +39,7 @@ def read_OMPS_nm(files):
             except (KeyError, ValueError) as e:
                 # KeyError occurs in load when file exists but contains no data
                 # ValueError occurs in concat when file cross-track dimensions are different than other files loaded
-                print(f"warning: skipping {filename}. {type(e).__name__} occured: {e}")
+                print(f"warning: skipping {filename}. {type(e).__name__} occurred: {e}")
     if count == 0:
         raise RuntimeError(f"no files loaded from files={files}")
     return data_array

--- a/monetio/sat/_omps_nadir_mm.py
+++ b/monetio/sat/_omps_nadir_mm.py
@@ -13,7 +13,7 @@ def read_OMPS_nm(files):
     import xarray as xr
 
     count = 0
-    print(files)
+    #print(files)
     # Check if files are url
     if "https" in files[0]:
         filelist = sorted(files)
@@ -26,17 +26,21 @@ def read_OMPS_nm(files):
             else:
                 data_array = xr.concat([data_array, data], "x")
     else:
-        filelist = sorted(glob(files, recursive=False))
-
+        if isinstance(files,str):
+            filelist = sorted(glob(files, recursive=False))
+        else: 
+            filelist = files # assume list
         for filename in filelist:
-            data = extract_OMPS_nm(filename)
+            try:
+                data = extract_OMPS_nm(filename)
 
-            if count == 0:
-                data_array = data
-                count += 1
-            else:
-                data_array = xr.concat([data_array, data], "x")
-
+                if count == 0:
+                    data_array = data
+                    count += 1
+                else:
+                    data_array = xr.concat([data_array, data], "x")
+            except KeyError:
+                print(f'KeyError occured for: {filename}')
     return data_array
 
 

--- a/monetio/sat/_omps_nadir_mm.py
+++ b/monetio/sat/_omps_nadir_mm.py
@@ -23,12 +23,12 @@ def read_OMPS_nm(files):
                 count += 1
             else:
                 data_array = xr.concat([data_array, data], "x")
-    else:
-        if isinstance(files,str):
+    else: # using local files
+        if isinstance(files,str): # expansion of filestring to list
             filelist = sorted(glob(files, recursive=False))
-        else: 
+        else: # ensure provided filelist is sorted
             filelist = sorted(files) # assume list
-        for filename in filelist:
+        for filename in filelist: #extract data
             try:
                 data = extract_OMPS_nm(filename)
                 if count == 0:

--- a/monetio/sat/_omps_nadir_mm.py
+++ b/monetio/sat/_omps_nadir_mm.py
@@ -19,7 +19,6 @@ def read_OMPS_nm(files):
         filelist = sorted(files)
         for filename in filelist:
             data = extract_OMPS_nm_opendap(filename)
-            # print(data)
             if count == 0:
                 data_array = data
                 count += 1
@@ -33,7 +32,6 @@ def read_OMPS_nm(files):
         for filename in filelist:
             try:
                 data = extract_OMPS_nm(filename)
-                #print(data.dims)
                 if count == 0:
                     data_array = data
                     count += 1
@@ -45,7 +43,6 @@ def read_OMPS_nm(files):
             except ValueError as e:
                 print(f'ValueError occured for: {filename}')
                 print(e)
-            #print(data_array.dims)
     return data_array
 
 
@@ -163,5 +160,4 @@ def extract_OMPS_nm(fname):
         },
         attrs={"missing_value": -999},
     )
-    print(ds['time'][0],ds.dims)
     return ds

--- a/monetio/sat/_omps_nadir_mm.py
+++ b/monetio/sat/_omps_nadir_mm.py
@@ -36,12 +36,8 @@ def read_OMPS_nm(files):
                     count += 1
                 else:
                     data_array = xr.concat([data_array, data], "x")
-            except KeyError as e:
-                print(f'KeyError occured for: {filename}')
-                print(e)
-            except ValueError as e:
-                print(f'ValueError occured for: {filename}')
-                print(e)
+            except (KeyError, ValueError) as e:
+                print(f"warning: skipping {filename}. {type(e).__name__} occured: {e}")
     return data_array
 
 

--- a/monetio/sat/_omps_nadir_mm.py
+++ b/monetio/sat/_omps_nadir_mm.py
@@ -13,7 +13,6 @@ def read_OMPS_nm(files):
     import xarray as xr
 
     count = 0
-    #print(files)
     # Check if files are url
     if "https" in files[0]:
         filelist = sorted(files)


### PR DESCRIPTION
In testing the fix to the Melodies Monet driver I came across a small change I made to the OMPS reader that allows for using a list of files instead of expanding a string with glob to get the satellite files to read in. This change is necessary for processing over time intervals in Melodies Monet.