### PR TITLE
Add unit conversion, variable load limit to RAQMS

### DIFF
--- a/monetio/models/raqms.py
+++ b/monetio/models/raqms.py
@@ -35,7 +35,13 @@ def open_dataset(fname, convert_to_ppb=True, surf_only=False, **kwargs):
     return ds
 
 
-def open_mfdataset(fname, convert_to_ppb=True, surf_only=False, **kwargs):
+def open_mfdataset(
+    fname, 
+    convert_to_ppb=True, 
+    var_list=None,
+    surf_only=False, 
+    **kwargs
+):
     """Open a multiple file dataset from RAQMS output.
 
     Parameters
@@ -44,6 +50,10 @@ def open_mfdataset(fname, convert_to_ppb=True, surf_only=False, **kwargs):
         Files to be opened, expressed as a glob string or list of string paths.
     convert_to_ppb : boolean
         If true the units of the gas species will be converted to ppbv
+    var_list: list
+        List of variables to include in output. MELODIES-MONET only reads in
+        variables need to plot in order to save on memory and simulation cost
+        especially for vertical data. If None, will read in all model data.
         
     Returns
     -------
@@ -56,8 +66,11 @@ def open_mfdataset(fname, convert_to_ppb=True, surf_only=False, **kwargs):
             "in netCDF format."
             "Do not mix and match file types."
         )
-
-    ds = xr.open_mfdataset(names, concat_dim="time", drop_variables=["theta"], combine="nested")
+    if var_list is not None:
+        var_list.extend(['lat','lon',"IDATE", "Times","psfc","delp",'pdash'])
+        ds = xr.open_mfdataset(names, concat_dim="time", drop_variables=["theta"], combine="nested")[var_list]
+    else:
+        ds = xr.open_mfdataset(names, concat_dim="time", drop_variables=["theta"], combine="nested")
     ds = _fix(ds, surf_only=surf_only)
     
     # convert all gas species to ppbv

--- a/monetio/models/raqms.py
+++ b/monetio/models/raqms.py
@@ -51,7 +51,7 @@ def open_mfdataset(
     convert_to_ppb : boolean
         If true the units of the gas species will be converted to ppbv
     var_list: list
-        List of variables to include in output. MELODIES-MONET only reads in
+        List of variables to include in output. MELODIES-MONET should only read in
         variables need to plot in order to save on memory and simulation cost
         especially for vertical data. If None, will read in all model data.
         

--- a/monetio/models/raqms.py
+++ b/monetio/models/raqms.py
@@ -9,14 +9,16 @@ More information: http://raqms-ops.ssec.wisc.edu/
 import xarray as xr
 
 
-def open_dataset(fname, *, surf_only=False):
+def open_dataset(fname, convert_to_ppb=True, surf_only=False, **kwargs):
     """Open a single dataset from RAQMS output. Currently expects netCDF file format.
 
     Parameters
     ----------
     fname : str
         File to be opened.
-
+    convert_to_ppb : boolean
+        If true the units of the gas species will be converted to ppbv
+        
     Returns
     -------
     xarray.Dataset
@@ -33,14 +35,16 @@ def open_dataset(fname, *, surf_only=False):
     return ds
 
 
-def open_mfdataset(fname, *, surf_only=False):
+def open_mfdataset(fname, convert_to_ppb=True, surf_only=False, **kwargs):
     """Open a multiple file dataset from RAQMS output.
 
     Parameters
     ----------
     fname : str or list of str
         Files to be opened, expressed as a glob string or list of string paths.
-
+    convert_to_ppb : boolean
+        If true the units of the gas species will be converted to ppbv
+        
     Returns
     -------
     xarray.Dataset
@@ -55,6 +59,14 @@ def open_mfdataset(fname, *, surf_only=False):
 
     ds = xr.open_mfdataset(names, concat_dim="time", drop_variables=["theta"], combine="nested")
     ds = _fix(ds, surf_only=surf_only)
+    
+    # convert all gas species to ppbv
+    if convert_to_ppb:
+        for i in ds.variables:
+            if "units" in ds[i].attrs:
+                if "ppv" in ds[i].attrs["units"]:
+                    ds[i] *= 1e9
+                    ds[i].attrs["units"] = "ppbv"
 
     return ds
 

--- a/monetio/models/raqms.py
+++ b/monetio/models/raqms.py
@@ -32,6 +32,14 @@ def open_dataset(fname, convert_to_ppb=True, surf_only=False, **kwargs):
     ds = xr.open_dataset(names[0], drop_variables=["theta"])
     ds = _fix(ds, surf_only=surf_only)
 
+    # convert all gas species to ppbv
+    if convert_to_ppb:
+        for i in ds.variables:
+            if "units" in ds[i].attrs:
+                if "ppv" in ds[i].attrs["units"]:
+                    ds[i] *= 1e9
+                    ds[i].attrs["units"] = "ppbv"
+    
     return ds
 
 
@@ -67,7 +75,7 @@ def open_mfdataset(
             "Do not mix and match file types."
         )
     if var_list is not None:
-        var_list.extend(['lat','lon',"IDATE", "Times","psfc","delp",'pdash'])
+        var_list.extend(['lat','lon',"IDATE", "Times","psfc","delp",'pdash','ttheta'])
         ds = xr.open_mfdataset(names, concat_dim="time", drop_variables=["theta"], combine="nested")[var_list]
     else:
         ds = xr.open_mfdataset(names, concat_dim="time", drop_variables=["theta"], combine="nested")
@@ -80,7 +88,13 @@ def open_mfdataset(
                 if "ppv" in ds[i].attrs["units"]:
                     ds[i] *= 1e9
                     ds[i].attrs["units"] = "ppbv"
-
+    
+    if 'ttheta' in ds.keys():
+        # Calculate temperature from potential temperature
+        k = 0.28571428571428564 # metpy.constants kappa
+        ds['temperature_k'] = ds['ttheta']*(ds['pres_pa_mid']/100000)**k
+        ds['temperature_k'].attrs['units'] = 'K'
+    
     return ds
 
 

--- a/monetio/models/raqms.py
+++ b/monetio/models/raqms.py
@@ -46,7 +46,7 @@ def open_mfdataset(fname, *, convert_to_ppb=True, var_list=None, surf_only=False
         If true the units of the gas species will be converted to ppbv
     var_list : list of str, optional
         List of variables to include in output. MELODIES MONET should only read in
-        variables need to plot in order to save on memory and simulation cost
+        variables needed to plot in order to save on memory and simulation cost
         especially for vertical data. If ``None`` (default), will read in all model data.
 
     Returns

--- a/monetio/models/raqms.py
+++ b/monetio/models/raqms.py
@@ -9,7 +9,7 @@ More information: http://raqms-ops.ssec.wisc.edu/
 import xarray as xr
 
 
-def open_dataset(fname, convert_to_ppb=True, surf_only=False):
+def open_dataset(fname, *, convert_to_ppb=True, surf_only=False):
     """Open a single dataset from RAQMS output. Currently expects netCDF file format.
 
     Parameters

--- a/monetio/models/raqms.py
+++ b/monetio/models/raqms.py
@@ -81,7 +81,8 @@ def _fix(ds, *, surf_only, convert_to_ppb):
         for i in ds.variables:
             if "units" in ds[i].attrs:
                 if ds[i].attrs["units"] == "ppv":
-                    ds[i] *= 1e9
+                    with xr.set_options(keep_attrs=True):
+                        ds[i] = ds[i] * 1e9
                     ds[i].attrs["units"] = "ppbv"
 
     if "ttheta" in ds.keys():

--- a/monetio/models/raqms.py
+++ b/monetio/models/raqms.py
@@ -9,16 +9,16 @@ More information: http://raqms-ops.ssec.wisc.edu/
 import xarray as xr
 
 
-def open_dataset(fname, convert_to_ppb=True, surf_only=False, **kwargs):
+def open_dataset(fname, convert_to_ppb=True, surf_only=False):
     """Open a single dataset from RAQMS output. Currently expects netCDF file format.
 
     Parameters
     ----------
     fname : str
         File to be opened.
-    convert_to_ppb : boolean
+    convert_to_ppb : bool
         If true the units of the gas species will be converted to ppbv
-        
+
     Returns
     -------
     xarray.Dataset
@@ -30,39 +30,25 @@ def open_dataset(fname, convert_to_ppb=True, surf_only=False, **kwargs):
         )
 
     ds = xr.open_dataset(names[0], drop_variables=["theta"])
-    ds = _fix(ds, surf_only=surf_only)
+    ds = _fix(ds, surf_only=surf_only, convert_to_ppb=convert_to_ppb)
 
-    # convert all gas species to ppbv
-    if convert_to_ppb:
-        for i in ds.variables:
-            if "units" in ds[i].attrs:
-                if "ppv" in ds[i].attrs["units"]:
-                    ds[i] *= 1e9
-                    ds[i].attrs["units"] = "ppbv"
-    
     return ds
 
 
-def open_mfdataset(
-    fname, 
-    convert_to_ppb=True, 
-    var_list=None,
-    surf_only=False, 
-    **kwargs
-):
+def open_mfdataset(fname, convert_to_ppb=True, var_list=None, surf_only=False):
     """Open a multiple file dataset from RAQMS output.
 
     Parameters
     ----------
     fname : str or list of str
         Files to be opened, expressed as a glob string or list of string paths.
-    convert_to_ppb : boolean
+    convert_to_ppb : bool
         If true the units of the gas species will be converted to ppbv
-    var_list: list
-        List of variables to include in output. MELODIES-MONET should only read in
+    var_list : list of str, optional
+        List of variables to include in output. MELODIES MONET should only read in
         variables need to plot in order to save on memory and simulation cost
-        especially for vertical data. If None, will read in all model data.
-        
+        especially for vertical data. If ``None`` (default), will read in all model data.
+
     Returns
     -------
     xarray.Dataset
@@ -74,37 +60,35 @@ def open_mfdataset(
             "in netCDF format."
             "Do not mix and match file types."
         )
+    ds = xr.open_mfdataset(names, concat_dim="time", drop_variables=["theta"], combine="nested")
     if var_list is not None:
-        var_list.extend(['lat','lon',"IDATE", "Times","psfc","delp",'pdash','ttheta'])
-        ds = xr.open_mfdataset(names, concat_dim="time", drop_variables=["theta"], combine="nested")[var_list]
-    else:
-        ds = xr.open_mfdataset(names, concat_dim="time", drop_variables=["theta"], combine="nested")
-    ds = _fix(ds, surf_only=surf_only)
-    
-    # convert all gas species to ppbv
-    if convert_to_ppb:
-        for i in ds.variables:
-            if "units" in ds[i].attrs:
-                if "ppv" in ds[i].attrs["units"]:
-                    ds[i] *= 1e9
-                    ds[i].attrs["units"] = "ppbv"
-    
-    if 'ttheta' in ds.keys():
-        # Calculate temperature from potential temperature
-        k = 0.28571428571428564 # metpy.constants kappa
-        ds['temperature_k'] = ds['ttheta']*(ds['pres_pa_mid']/100000)**k
-        ds['temperature_k'].attrs['units'] = 'K'
-    
+        var_list.extend(["lat", "lon", "IDATE", "Times", "psfc", "delp", "pdash", "ttheta"])
+        ds = ds[var_list]
+    ds = _fix(ds, surf_only=surf_only, convert_to_ppb=convert_to_ppb)
+
     return ds
 
 
-def _fix(ds, *, surf_only):
+def _fix(ds, *, surf_only, convert_to_ppb):
     ds = _fix_grid(ds)
     ds = _fix_time(ds)
     ds = _fix_pres(ds)
 
     if surf_only:
         ds = ds.isel(z=0).expand_dims("z")
+
+    if convert_to_ppb:
+        for i in ds.variables:
+            if "units" in ds[i].attrs:
+                if ds[i].attrs["units"] == "ppv":
+                    ds[i] *= 1e9
+                    ds[i].attrs["units"] = "ppbv"
+
+    if "ttheta" in ds.keys():
+        # Calculate temperature from potential temperature
+        k = 0.28571428571428564  # R/cp = kappa (unitless; value for dry air from metpy.constants)
+        ds["temperature_k"] = ds["ttheta"] * (ds["pres_pa_mid"] / 100000) ** k
+        ds["temperature_k"].attrs["units"] = "K"
 
     ds = ds.transpose("time", "z", "y", "x")
 

--- a/monetio/models/raqms.py
+++ b/monetio/models/raqms.py
@@ -35,7 +35,7 @@ def open_dataset(fname, *, convert_to_ppb=True, surf_only=False):
     return ds
 
 
-def open_mfdataset(fname, convert_to_ppb=True, var_list=None, surf_only=False):
+def open_mfdataset(fname, *, convert_to_ppb=True, var_list=None, surf_only=False):
     """Open a multiple file dataset from RAQMS output.
 
     Parameters

--- a/monetio/sat/_tropomi_l2_no2_mm.py
+++ b/monetio/sat/_tropomi_l2_no2_mm.py
@@ -82,6 +82,7 @@ def _open_one_dataset(fname, variable_dict):
 
             itrop_ = get_extra("tm5_tropopause_layer_index", dct_=dct)
             itrop_[itrop_ == 0] = 1  # Avoid trop in surface layer
+
             itrop = xr.DataArray(itrop_, dims=("y", "x"))
             a = xr.DataArray(data=get_extra("tm5_constant_a", dct_=dct), dims=("z", "v"))
             b = xr.DataArray(data=get_extra("tm5_constant_b", dct_=dct), dims=("z", "v"))
@@ -102,10 +103,10 @@ def _open_one_dataset(fname, variable_dict):
 
             # Tropopause pressure
             ptrop = xr.full_like(itrop, np.nan, dtype=ds["preslev"].dtype)
+            print(np.unique(itrop))
             for i in np.unique(itrop):
-                if np.isnan(i):
-                    continue
-                ptrop = xr.where(itrop == i, p.isel(z=int(i)), ptrop)
+                if i >= 0 and i < p.sizes['z']:
+                    ptrop = xr.where(itrop == i, p.isel(z=int(i)), ptrop)
             ds["troppres"] = ptrop
             ds["troppres"].attrs.update({"long_name": "tropopause pressure", "units": "Pa"})
 

--- a/monetio/sat/_tropomi_l2_no2_mm.py
+++ b/monetio/sat/_tropomi_l2_no2_mm.py
@@ -82,7 +82,6 @@ def _open_one_dataset(fname, variable_dict):
 
             itrop_ = get_extra("tm5_tropopause_layer_index", dct_=dct)
             itrop_[itrop_ == 0] = 1  # Avoid trop in surface layer
-
             itrop = xr.DataArray(itrop_, dims=("y", "x"))
             a = xr.DataArray(data=get_extra("tm5_constant_a", dct_=dct), dims=("z", "v"))
             b = xr.DataArray(data=get_extra("tm5_constant_b", dct_=dct), dims=("z", "v"))
@@ -103,12 +102,10 @@ def _open_one_dataset(fname, variable_dict):
 
             # Tropopause pressure
             ptrop = xr.full_like(itrop, np.nan, dtype=ds["preslev"].dtype)
-            print(np.unique(itrop))
             for i in np.unique(itrop):
                 if np.isnan(i) or i < 0 or i >= p.sizes["z"]:
                     continue
                 ptrop = xr.where(itrop == i, p.isel(z=int(i)), ptrop)
-
             ds["troppres"] = ptrop
             ds["troppres"].attrs.update({"long_name": "tropopause pressure", "units": "Pa"})
 

--- a/tests/test_raqms.py
+++ b/tests/test_raqms.py
@@ -38,6 +38,11 @@ def _test_ds(ds):
 
     assert tuple(ds.o3vmr.dims) == ("time", "z", "y", "x")
 
+    # Test conversion of gases to ppbv worked
+    assert ds["o3vmr"].units == "ppbv"
+
+    assert "temperature_k" in ds.data_vars
+
 
 def test_open_dataset():
     ds = raqms.open_dataset(TEST_FP)


### PR DESCRIPTION
Additions to RAQMS reader:

1) Convert gases to ppbv ; resolves #134 
2) option for loading a small set of variables (consistent with _mm readers)

Before merging plan to add renaming or calculation for temperature_k and dz_m (needed for some aircraft and satellite pairings). These updates will be post-tutorial.