### PR TITLE
Add capability to read HCHO

### DIFF
--- a/monetio/sat/_tempo_l2_no2_mm.py
+++ b/monetio/sat/_tempo_l2_no2_mm.py
@@ -9,7 +9,6 @@ import logging
 import os
 import sys
 import warnings
-from collections import OrderedDict
 from glob import glob
 from pathlib import Path
 
@@ -76,6 +75,8 @@ def _open_one_dataset(fname, variable_dict):
             "vertical_column_troposphere",
             "vertical_column_stratosphere",
             "vertical_column_troposphere_uncertainty",
+            "vertical_column",
+            "vertical_column_uncertainty",
         ]:
             values_var = dso.groups["product"][varname]
         elif varname in [
@@ -102,6 +103,7 @@ def _open_one_dataset(fname, variable_dict):
             "gas_profile",
             "albedo",
             "temperature_profile",
+            "amf",
             "amf_total",
             "amf_diagnositc_flag",
             "eff_cloud_fraction",
@@ -109,6 +111,7 @@ def _open_one_dataset(fname, variable_dict):
             "amf_cloud_pressure",
             "amf_troposphere",
             "amf_stratosphere",
+            "background_correction",
         ]:
             values_var = dso.groups["support_data"][varname]
         elif varname in ["fit_rms_residual", "fit_convergence_flag"]:
@@ -237,7 +240,7 @@ def open_dataset(fnames, variable_dict, debug=False):
     print(fnames)
     files = sorted(glob(fnames))
 
-    granules = OrderedDict()
+    granules = {}
 
     for file in files:
         granule = _open_one_dataset(file, variable_dict)

--- a/monetio/sat/_tempo_l2_no2_mm.py
+++ b/monetio/sat/_tempo_l2_no2_mm.py
@@ -105,7 +105,7 @@ def _open_one_dataset(fname, variable_dict):
             "temperature_profile",
             "amf",
             "amf_total",
-            "amf_diagnositc_flag",
+            "amf_diagnostic_flag",
             "eff_cloud_fraction",
             "amf_cloud_fraction",
             "amf_cloud_pressure",


### PR DESCRIPTION
These simple changes add the capability of reading HCHO.
I should probably change the name (_tempo_l2_mm.py? _tempo_l2_mm_no2_hcho.py?), but I thought that I should do so directly when we abandon the _mm convention in next version of MONETIO.
I also took the oportunity to change the OrderedDict by a dict.
Cheers
Pablo