### PR TITLE
DOC: Specify py2k-compatible version in py3k statement

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ air quality models.
 
 MONET was developed to evaluate the Community Multiscale Air Quality Model (CMAQ)
 for the NOAA National Air Quality Forecast Capability (NAQFC) modeling system.
-From MONET version 2.1.4, MONETIO was broken off from MONET to be its own dedicated repository.
+From MONET version 2.1.4, MONETIO was broken off from MONET to be its own dedicated repository [#monetio-split]_.
 MONETIO is built to work in unison with MONET. For more information on MONET please refer to
 https://monet-arl.readthedocs.io.
 
@@ -78,7 +78,6 @@ Supported datasets
 * `IMPROVE <http://vista.cira.colostate.edu/Improve/>`_
 * `ISH <https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database>`_
 
-
 .. toctree::
    :maxdepth: 10
    :caption: Help & Reference
@@ -86,3 +85,9 @@ Supported datasets
 
    api
    get-in-touch
+
+.. rubric:: Footnotes
+
+.. [#monetio-split] The last commit of [MONET v2.1.5](https://github.com/noaa-oar-arl/monet/releases/tag/v2.1.5)
+    merged noaa-oar-arl/monet#77, which brought the branch testing the split MONET and MONETIO packages into the
+    primary branch of the repository.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ air quality models.
 
 MONET was developed to evaluate the Community Multiscale Air Quality Model (CMAQ)
 for the NOAA National Air Quality Forecast Capability (NAQFC) modeling system.
-From MONET version 2.1.4, MONETIO was broken off from MONET to be its own dedicated repository [#monetio-split]_.
+After MONET version 2.1.4, MONETIO was broken off from MONET to be its own dedicated repository [#monetio-split]_.
 MONETIO is built to work in unison with MONET. For more information on MONET please refer to
 https://monet-arl.readthedocs.io.
 
@@ -88,6 +88,8 @@ Supported datasets
 
 .. rubric:: Footnotes
 
-.. [#monetio-split] The last commit of [MONET v2.1.5](https://github.com/noaa-oar-arl/monet/releases/tag/v2.1.5)
-    merged noaa-oar-arl/monet#77, which brought the branch testing the split MONET and MONETIO packages into the
-    primary branch of the repository.
+.. [#monetio-split] The last commit of `MONET v2.1.5 <https://github.com/noaa-oar-arl/monet/releases/tag/v2.1.5>`__
+   merged `PR#77 <https://github.com/noaa-oar-arl/monet/pull/77>`__, which brought the branch testing the split MONET and MONETIO packages into the
+   primary branch of the repository.
+   The first official split GitHub releases with were `MONET v2.2.0 <https://github.com/noaa-oar-arl/monet/releases/tag/v2.2.0>`__
+   and `MONETIO v0.1 <https://github.com/noaa-oar-arl/monetio/releases/tag/v0.1>`__ (Mar 2020).

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -50,10 +50,10 @@ or you can manually download it from GitHub and install it using the setup.py::
 
 .. note::
    MONET plans to drop support for python 2.7 sometime in 2019. This
-   means that new releases of xarray published after this date will only be
-   installable on python 3+ environments, but older versions of xarray will
-   always be available to python 2.7 users. For more information see the
-   following references:
+   means that new releases of MONET and MONETIO published after this date will
+   only be installable on python 3+ environments, but older versions of MONET 
+   (<2.1.5) will always be available to python 2.7 users. For more information
+   see the following references:
 
       - `Python 3 Statement <https://python3statement.github.io/>`__
       - `Tips on porting to Python 3 <https://docs.python.org/3/howto/pyporting.html>`__

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -51,8 +51,8 @@ or you can manually download it from GitHub and install it using the setup.py::
 .. note::
    MONET plans to drop support for python 2.7 sometime in 2019. This
    means that new releases of MONET and MONETIO published after this date will
-   only be installable on python 3+ environments, but older versions of MONET 
-   (<2.1.5) will always be available to python 2.7 users. For more information
+   only be installable on python 3+ environments, but older versions of MONET
+   (< 2.1.5) will always be available to python 2.7 users. For more information
    see the following references:
 
       - `Python 3 Statement <https://python3statement.github.io/>`__


### PR DESCRIPTION
The `python>=3.6` requirement at the top of the file dates to early 2020, before v0.1 of MONETIO.  Before this, MONET and MONETIO were one package.  It looks like the last commit in [MONET 2.1.5](https://github.com/noaa-oar-arl/monet/releases/tag/v2.1.5) merges in the work to split MONET and MONETIO, so someone wanting MONETIO functionality from MONET would need a MONET version prior to that.