### PR TITLE
Group GML ozonesonde tests discovering files into one xdist group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,12 @@ jobs:
             aioitertools=0.11.0
 
       - name: Test with pytest
-        run: pytest -n auto -v -ra -W "ignore:Downloading test file:UserWarning::"
+        run: pytest -n auto --dist loadgroup -v -ra -W "ignore:Downloading test file:UserWarning::"
 
       - name: Test with pytspack installed
         run: |
           pip install https://github.com/noaa-oar-arl/pytspack/archive/master.zip
-          pytest -n auto --dist loadgroup -v -rsx -k with_pytspack
+          pytest -k with_pytspack -n auto -v -ra -W "ignore:API key length is 0:UserWarning::"
 
   docs:
     name: Check docs build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Test with pytspack installed
         run: |
           pip install https://github.com/noaa-oar-arl/pytspack/archive/master.zip
-          pytest -n auto -v -rsx -k with_pytspack
+          pytest -n auto --dist loadgroup -v -rsx -k with_pytspack
 
   docs:
     name: Check docs build

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,6 +27,7 @@ dependencies:
   # test
   - filelock
   - pytest
+  - pytest-order
   - pytest-xdist
   #
   - pip>=21.1

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,7 +27,6 @@ dependencies:
   # test
   - filelock
   - pytest
-  - pytest-order
   - pytest-xdist
   #
   - pip>=21.1

--- a/tests/test_gml_ozonesonde.py
+++ b/tests/test_gml_ozonesonde.py
@@ -3,10 +3,11 @@ import pytest
 
 from monetio import gml_ozonesonde
 
-discover = pytest.mark.xdist_group(name="discover")
+uses_get_files = pytest.mark.xdist_group(name="get-files")
 
 
-@discover
+@pytest.mark.order(1)
+@uses_get_files
 def test_discover_files():
     files = gml_ozonesonde.discover_files()
     assert len(files) > 0
@@ -63,7 +64,7 @@ def test_read_100m_bad_header_line():
         _ = gml_ozonesonde.read_100m(url)
 
 
-@discover
+@uses_get_files
 def test_add_data():
     dates = pd.date_range("2023-01-01", "2023-01-31 23:59", freq="H")
     df = gml_ozonesonde.add_data(dates, n_procs=2)
@@ -78,7 +79,7 @@ def test_add_data():
     assert df["siteid"].nunique() == latlon.nunique()
 
 
-@discover
+@uses_get_files
 def test_add_data_location_sel():
     dates = pd.date_range("2023-01-01", "2023-01-31 23:59", freq="H")
     df = gml_ozonesonde.add_data(
@@ -102,7 +103,7 @@ def test_add_data_invalid_location(location):
         _ = gml_ozonesonde.add_data(dates, location=location)
 
 
-@discover
+@uses_get_files
 def test_same_location_and_launch_time():
     # Two files with same file time and launch time:
     # - https://gml.noaa.gov/aftp/data/ozwv/Ozonesonde/Boulder,%20Colorado/100%20Meter%20Average%20Files/bl774_2003_03_10_20.l100

--- a/tests/test_gml_ozonesonde.py
+++ b/tests/test_gml_ozonesonde.py
@@ -3,7 +3,10 @@ import pytest
 
 from monetio import gml_ozonesonde
 
+discover = pytest.mark.xdist_group(name="discover")
 
+
+@discover
 def test_discover_files():
     files = gml_ozonesonde.discover_files()
     assert len(files) > 0
@@ -60,6 +63,7 @@ def test_read_100m_bad_header_line():
         _ = gml_ozonesonde.read_100m(url)
 
 
+@discover
 def test_add_data():
     dates = pd.date_range("2023-01-01", "2023-01-31 23:59", freq="H")
     df = gml_ozonesonde.add_data(dates, n_procs=2)
@@ -74,6 +78,7 @@ def test_add_data():
     assert df["siteid"].nunique() == latlon.nunique()
 
 
+@discover
 def test_add_data_location_sel():
     dates = pd.date_range("2023-01-01", "2023-01-31 23:59", freq="H")
     df = gml_ozonesonde.add_data(

--- a/tests/test_gml_ozonesonde.py
+++ b/tests/test_gml_ozonesonde.py
@@ -6,7 +6,6 @@ from monetio import gml_ozonesonde
 uses_get_files = pytest.mark.xdist_group(name="get-files")
 
 
-@pytest.mark.order(1)
 @uses_get_files
 def test_discover_files():
     files = gml_ozonesonde.discover_files(n_threads=2)

--- a/tests/test_gml_ozonesonde.py
+++ b/tests/test_gml_ozonesonde.py
@@ -9,7 +9,7 @@ uses_get_files = pytest.mark.xdist_group(name="get-files")
 @pytest.mark.order(1)
 @uses_get_files
 def test_discover_files():
-    files = gml_ozonesonde.discover_files()
+    files = gml_ozonesonde.discover_files(n_threads=2)
     assert len(files) > 0
     assert set(files["location"].unique()) == set(gml_ozonesonde.LOCATIONS)
 

--- a/tests/test_gml_ozonesonde.py
+++ b/tests/test_gml_ozonesonde.py
@@ -102,6 +102,7 @@ def test_add_data_invalid_location(location):
         _ = gml_ozonesonde.add_data(dates, location=location)
 
 
+@discover
 def test_same_location_and_launch_time():
     # Two files with same file time and launch time:
     # - https://gml.noaa.gov/aftp/data/ozwv/Ozonesonde/Boulder,%20Colorado/100%20Meter%20Average%20Files/bl774_2003_03_10_20.l100


### PR DESCRIPTION
In combination with #225 , this should make the tests more robust.

Another option would be to use `--dist loadfile` instead, so all the tests in the file are run by the same worker. Could combine with pytest-order to ensure that the discover-files test runs first, populating the cache.