### PR TITLE
Updates to CESM-FV Reader

### DIFF
--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -70,6 +70,7 @@ def open_mfdataset(
     if not surf_only:
         dset_load["pres_pa_int"] = _calc_pressure_i(dset_load)
         var_list.append("pres_pa_int")
+        # Pressure at the interface
         if "PMID" not in dset_load.keys():
             dset_load["PMID"] = _calc_pressure(dset_load)
         var_list = var_list + ["pres_pa_mid"]

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -68,25 +68,28 @@ def open_mfdataset(
     # extract variables of choice
     # If vertical information is required, add it.
     if not surf_only:
+	# add pressure at the interface 
         dset_load["pres_pa_int"] = _calc_pressure_i(dset_load)
         var_list.append("pres_pa_int")
-        # Pressure at the interface
+        #import pdb; pdb.set_trace()  # debug 
         if "PMID" not in dset_load.keys():
             dset_load["PMID"] = _calc_pressure(dset_load)
         var_list = var_list + ["pres_pa_mid"]
         if "Z3" not in dset_load.keys():
             warnings.warn("Geopotential height Z3 is not in model keys. Assuming hydrostatic runs")
             dset_load["Z3"] = _calc_hydrostatic_height(dset_load)
-
-        dset_load.rename(
-            {
-                "T": "temperature_k",
-                "Z3": "alt_msl_m_mid",
-                "PS": "surfpres_pa",
-                "PMID": "pres_pa_mid",
-            }
+        var_list = var_list + ["alt_msl_m_mid"]
+        
+        dset_load =  dset_load.rename(
+                        {
+                            "T": "temperature_k",
+                            "Z3": "alt_msl_m_mid",
+                            "PS": "surfpres_pa",
+                            "PMID": "pres_pa_mid"
+                        }
         )
         # Calc height agl. PHIS is in m2/s2, whereas Z3 is in already in m
+        #import pdb; pdb.set_trace()
         dset_load["alt_agl_m_mid"] = dset_load["alt_msl_m_mid"] - dset_load["PHIS"] / 9.80665
         dset_load["alt_agl_m_mid"].attrs = {
             "description": "geopotential height above ground level",
@@ -255,8 +258,9 @@ def _calc_pressure_i(dset):
         p0 = dset["P0"].values
 
     for nlev in range(n_vert):
+        #import pdb; pdb.set_trace()
         pressure_i[:, nlev, :, :] = (
-            dset["hyai"][nlev].values * p0 + dset["hybi"][nlev].values * dset["PS"].values
+            dset["hyai"][0, nlev].values * p0 + dset["hybi"][0, nlev].values * dset["PS"].values
         )
     P_int = xr.DataArray(
         data=pressure_i,

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -388,7 +388,7 @@ def _calc_layer_thickness_i(dset):
 
     Parameters
     ----------
-    dset: xr.Dataset
+    dset : xr.Dataset
 
     Returns
     ----------

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -408,4 +408,4 @@ def _calc_layer_thickness_i(dset):
         coords={"time": dset.time, "lev": dset.lev, "lat": dset.lat, "lon": dset.lon},
         attrs={"description": "Layer Thickness (based on interface pressure)", "units": "m"},
     )
-    return dz_m 
+    return dz_m

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -332,7 +332,7 @@ def _calc_hydrostatic_height_i(dset):
 
     Parameters
     ----------
-    dset: xr.Dataset
+    dset : xr.Dataset
 
     Returns
     -------

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -75,7 +75,6 @@ def open_mfdataset(
             dset_load["Z3"] = _calc_hydrostatic_height(dset_load)
         var_list = var_list + ["alt_msl_m_mid"]
 
-        # nori mod: 
         # calc layer thickness if hyai and hybi exist
         if "hyai" and "hybi" in dset_load.keys():
             dset_load["pres_pa_int"] = _calc_pressure_i(dset_load)
@@ -129,7 +128,6 @@ def open_mfdataset(
     # re-order so surface is associated with the first vertical index
     dset = dset.sortby("z", ascending=False)
 
-    # nori mod: 
     # if pres_pa_int exists, reorder so surface is first vertical level
     if "pres_pa_int" in dset.keys():
         dset = dset.sortby("ilev", ascending=False) 
@@ -329,7 +327,6 @@ def _calc_hydrostatic_height(dset):
     )
     return z
 
-# nori mod
 def _calc_hydrostatic_height_i(dset):
     """Calculates interface layer height using pres_pa_int, PHIS, and T.
 
@@ -380,7 +377,6 @@ def _calc_hydrostatic_height_i(dset):
     )
     return z 
 
-# nori mod
 def _calc_layer_thickness_i(dset):
     """
     Calculates layer thickness (dz_m) from interface heights. 

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -339,7 +339,7 @@ def _calc_hydrostatic_height_i(dset):
     xr.DataArray
     """
     R = 8.314  # Pa * m3 / mol K
-    M_AIR = 0.028  # kg / mol
+    M_AIR = 0.029  # kg / mol
     GRAVITY = 9.80665  # m / s2
 
     time = dset.time.values

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -237,7 +237,7 @@ def _calc_pressure_i(dset):
 
     Parameters
     ----------
-    dset: xr.Dataset
+    dset : xr.Dataset
 
     Returns
     -------

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -78,8 +78,6 @@ def open_mfdataset(
         # calc layer thickness if hyai and hybi exist
         if "hyai" and "hybi" in dset_load.keys():
             dset_load["pres_pa_int"] = _calc_pressure_i(dset_load)
-            var_list.append("pres_pa_int")
-
             dset_load["dz_m"] = _calc_layer_thickness_i(dset_load)
             var_list.append("dz_m")
        
@@ -128,10 +126,6 @@ def open_mfdataset(
     # re-order so surface is associated with the first vertical index
     dset = dset.sortby("z", ascending=False)
 
-    # if pres_pa_int exists, reorder so surface is first vertical level
-    if "pres_pa_int" in dset.keys():
-        dset = dset.sortby("ilev", ascending=False) 
-    
     # Get rid of original 1-D lat and lon to avoid future conflicts
     dset = dset.drop_vars(["lat", "lon"])
 

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -46,7 +46,6 @@ def open_mfdataset(
             + "and has not been properly tested. Use at own risk."
         )
 
-    from pyresample.utils import wrap_longitudes
 
     # check that the files are netcdf format
     names, netcdf = _ensure_mfdataset_filenames(fname)
@@ -107,9 +106,12 @@ def open_mfdataset(
     # rename altitude dimension to z for monet use
     # also rename lon to x and lat to y
     dset = dset.rename_dims({"lon": "x", "lat": "y", "lev": "z"})
+    if np.any(dset["lon"] > 180):
+        dset["lon"] = (dset["lon"] + 180) % 360 - 180
+        dset = dset.sortby("lon")
 
     # convert to -180 to 180 longitude
-    lon = wrap_longitudes(dset["lon"])
+    lon = dset["lon"]
     lat = dset["lat"]
     lons, lats = meshgrid(lon, lat)
     dset["longitude"] = (("y", "x"), lons)

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -216,7 +216,7 @@ def _calc_pressure(dset):
     )
     return P
 
-def _calc_pressure(dset):
+def _calc_pressure_i(dset):
     """Calculates interface layer pressure using P0, PS, hyai, hybi
 
     Parameters

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -246,9 +246,9 @@ def _calc_pressure_i(dset):
     presvars = ["PS", "hyai", "hybi"]
     if not all(pvar in list(dset.keys()) for pvar in presvars):
         raise KeyError(
-            "The model does not have the variables to calculate"
-            + "the pressure required for satellite comparison"
-            + "If the vertical coordinate is not needed, set surface_only=True"
+            "The model does not have the variables to calculate "
+            "the pressure required for satellite comparison. "
+            "If the vertical coordinate is not needed, set surface_only=True"
         )
     time = dset["PS"].time.values
     vert = dset["hyai"].ilev.values

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -68,9 +68,11 @@ def open_mfdataset(
     # extract variables of choice
     # If vertical information is required, add it.
     if not surf_only:
+        dset_load["pres_pa_int"] = _calc_pressure_i(dset_load)
+        var_list.append("pres_pa_int")
         if "PMID" not in dset_load.keys():
             dset_load["PMID"] = _calc_pressure(dset_load)
-        var_list = var_list + ["PMID"]
+        var_list = var_list + ["pres_pa_mid"]
         if "Z3" not in dset_load.keys():
             warnings.warn("Geopotential height Z3 is not in model keys. Assuming hydrostatic runs")
             dset_load["Z3"] = _calc_hydrostatic_height(dset_load)

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -348,9 +348,9 @@ def _calc_hydrostatic_height_i(dset):
     # pressure levels should be increasing.
     _height_decreasing = np.all(ilev[:-1] < ilev[1:])
     if not _height_decreasing:
-        raise Exception(
-            "Expected default CESM behaviour:"
-            + "pressure levels should be in increasing order, height in decreasing order"
+        raise ValueError(
+            "Expected default CESM behaviour "
+            "(pressure levels should be in increasing order, height in decreasing order)"
         )
     # surface geopotential height (PHIS / g)
     height = np.zeros((len(time), len(ilev), len(lat), len(lon)))

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -75,7 +75,7 @@ def open_mfdataset(
         var_list = var_list + ["alt_msl_m_mid"]
 
         # calc layer thickness if hyai and hybi exist
-        if "hyai" and "hybi" in dset_load.keys():
+        if {"hyai", "hybi"} <= dset_load.keys():
             dset_load["pres_pa_int"] = _calc_pressure_i(dset_load)
             dset_load["dz_m"] = _calc_layer_thickness_i(dset_load)
             var_list.append("dz_m")

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -71,15 +71,32 @@ def open_mfdataset(
         if "Z3" not in dset_load.keys():
             warnings.warn("Geopotential height Z3 is not in model keys. Assuming hydrostatic runs")
             dset_load["Z3"] = _calc_hydrostatic_height(dset_load)
+        if "PS" in dset_load.keys():
+            dset_load["PS"].rename("pres_pa_mid")
+        else:
+            warnings.warn("Surface pressure (PS) is not in model keys. Continuing without it.")
+        if "PHIS" in dset_load.keys():
+            # calc height agl. PHIS in m2/s2, where Z3 already in m
+            dset_load["alt_agl_m_mid"] = dset_load["alt_msl_m_mid"] - dset_load["PHIS"] / 9.80665
+            dset_load["alt_agl_m_mid"].attrs = {
+                "description": "geopotential height above ground level",
+                "units": "m",
+            }
+        else:
+            warnings.warn("PHIS is not in model keys. Continuing without it.")
 
         # calc layer thickness if hyai and hybi exist
-        if {"hyai", "hybi"} <= dset_load.keys():
+        if {"hyai", "hybi", "PHIS"} <= dset_load.keys():
             dset_load["pres_pa_int"] = _calc_pressure_i(dset_load)
             dset_load["dz_m"] = _calc_layer_thickness_i(dset_load)
             var_list.append("dz_m")
+        elif {"PDELDRY"} <= dset_load.keys():
+            dset_load["dz_m"] = _calc_layer_thickness_mid(dset_load)
+            var_list.append("dz_m")
         else:
             print(
-                "The model dataset does not contain 'hyai' or 'hybi'."
+                "The model dataset does not contain 'hyai' or 'hybi' for layer_thickness "
+                "calculation at the interface, or 'PDELDDRY' for calculation using midlayer. "
                 "Skipping layer thickness calculations (dz_m)."
             )
 
@@ -87,22 +104,22 @@ def open_mfdataset(
             {
                 "T": "temperature_k",
                 "Z3": "alt_msl_m_mid",
-                "PS": "surfpres_pa",
+                # "PS": "surfpres_pa",
                 "PMID": "pres_pa_mid",
             }
         )
         # Calc height agl. PHIS is in m2/s2, whereas Z3 is in already in m
-        dset_load["alt_agl_m_mid"] = dset_load["alt_msl_m_mid"] - dset_load["PHIS"] / 9.80665
-        dset_load["alt_agl_m_mid"].attrs = {
-            "description": "geopotential height above ground level",
-            "units": "m",
-        }
+        # dset_load["alt_agl_m_mid"] = dset_load["alt_msl_m_mid"] - dset_load["PHIS"] / 9.80665
+        # dset_load["alt_agl_m_mid"].attrs = {
+        #    "description": "geopotential height above ground level",
+        #    "units": "m",
+        # }
 
         var_list = var_list + [
             "temperature_k",
             "alt_msl_m_mid",
-            "alt_agl_m_mid",
-            "surfpres_pa",
+            #   "alt_agl_m_mid",
+            #  "surfpres_pa",
             "pres_pa_mid",
         ]
 
@@ -412,6 +429,47 @@ def _calc_layer_thickness_i(dset):
     dz_m = np.zeros((len(dset.time), len(dset.lev), len(dset.lat), len(dset.lon)))
     for nlev in range(len(dset.lev)):
         dz_m[:, nlev, :, :] = z_int[:, nlev, :, :] - z_int[:, nlev + 1, :, :]
+
+    dz_m = xr.DataArray(
+        data=dz_m,
+        dims=["time", "lev", "lat", "lon"],
+        coords={"time": dset.time, "lev": dset.lev, "lat": dset.lat, "lon": dset.lon},
+        attrs={"description": "Layer Thickness (based on interface pressure)", "units": "m"},
+    )
+    return dz_m
+
+
+def _calc_layer_thickness_mid(dset):
+    """
+    Calculates layer thickness (dz_m) when hybrid variables
+    (hyai, hybi) are not provided.
+    Note: This calculates based on pressure being in increasing order,
+    and altitude in decreasing order. The code flips all the variables
+    along the 'z' dimensions at the end.
+    This uses PDELDRY, T, and pres_pa_mid.
+
+    Parameters
+    ----------
+    dset: xr.Dataset
+
+    Returns
+    ----------
+    xr.DataArray
+        Layer Thickness (m)
+    """
+
+    GRAVITY = 9.80665  # m / s2
+    RGAS = 287.04
+
+    # # compute layer thickness
+    dz_m = np.zeros((len(dset.time), len(dset.lev), len(dset.lat), len(dset.lon)))
+    for nlev in range(len(dset.lev)):
+        dp = dset["PDELDRY"].isel(lev=nlev).values  # Dry pressure difference between levels [Pa]
+        temp = dset["T"].isel(lev=nlev).values  # midlayer temp approx
+        pmid = dset["PMID"].isel(lev=nlev)
+        rho = pmid / RGAS / temp
+        # dz in m [Pa]/[m/s2]/[Pa/(K-m2/K/s2)]
+        dz_m[:, nlev, :, :] = dp / rho / GRAVITY
 
     dz_m = xr.DataArray(
         data=dz_m,

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -6,10 +6,6 @@ import numpy as np
 import xarray as xr
 from numpy import meshgrid
 
-# -- TO DO:
-# need to have the code be able to read additional variables when surf_only = false
-# currently does it when its true .. can base it off of if not surf_only section
-
 
 def open_mfdataset(
     fname,
@@ -81,7 +77,7 @@ def open_mfdataset(
             warnings.warn("Surface pressure (PS) is not in model keys. Continuing without it.")
         if "PHIS" in dset_load.keys():
             # calc height agl. PHIS in m2/s2, where Z3 already in m
-            dset_load["alt_agl_m_mid"] = dset_load["alt_msl_m_mid"] - dset_load["PHIS"] / 9.80665
+            dset_load["alt_agl_m_mid"] = dset_load["Z3"] - dset_load["PHIS"] / 9.80665
             dset_load["alt_agl_m_mid"].attrs = {
                 "description": "geopotential height above ground level",
                 "units": "m",
@@ -110,21 +106,12 @@ def open_mfdataset(
                 "PMID": "pres_pa_mid",
             }
         )
-        # Calc height agl. PHIS is in m2/s2, whereas Z3 is in already in m
-        # dset_load["alt_agl_m_mid"] = dset_load["alt_msl_m_mid"] - dset_load["PHIS"] / 9.80665
-        # dset_load["alt_agl_m_mid"].attrs = {
-        #    "description": "geopotential height above ground level",
-        #    "units": "m",
-        # }
 
         var_list = var_list + [
             "temperature_k",
             "alt_msl_m_mid",
-            #   "alt_agl_m_mid",
-            #  "surfpres_pa",
             "pres_pa_mid",
         ]
-
     dset = dset_load.get(var_list)
     # rename altitude dimension to z for monet use
     # also rename lon to x and lat to y
@@ -477,6 +464,6 @@ def _calc_layer_thickness_mid(dset):
         data=dz_m,
         dims=["time", "lev", "lat", "lon"],
         coords={"time": dset.time, "lev": dset.lev, "lat": dset.lat, "lon": dset.lon},
-        attrs={"description": "Layer Thickness (based on interface pressure)", "units": "m"},
+        attrs={"description": "Layer Thickness (based on midlayer pressure)", "units": "m"},
     )
     return dz_m

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -216,9 +216,15 @@ def _calc_pressure(dset):
     else:
         p0 = dset["P0"].values
 
+    # need to specify the time dimension because it is created
+    # when there are more that one model output files being read.
+    if "time" in dset["hyam"].dims:
+        dset["hyam"] = dset["hyam"].isel(time=0)
+        dset["hybm"] = dset["hybm"].isel(time=0)
+
     for nlev in range(n_vert):
         pressure[:, nlev, :, :] = (
-            dset["hyam"][nlev].values * p0 + dset["hybm"][nlev].values * dset["PS"].values
+            dset["hyam"][nlev].values * p0 + dset["hybm"][nlev].values * dset["PS"][:, :, :].values
         )
     P = xr.DataArray(
         data=pressure,
@@ -264,9 +270,15 @@ def _calc_pressure_i(dset):
     else:
         p0 = dset["P0"].values
 
+    # need to specify the time dimension because it is created
+    # when there are more that one model output files being read.
+    if "time" in dset["hyai"].dims:
+        dset["hyai"] = dset["hyai"].isel(time=0)
+        dset["hybi"] = dset["hybi"].isel(time=0)
+
     for nlev in range(n_vert):
         pressure_i[:, nlev, :, :] = (
-            dset["hyai"][0, nlev].values * p0 + dset["hybi"][0, nlev].values * dset["PS"].values
+            dset["hyai"][nlev].values * p0 + dset["hybi"][nlev].values * dset["PS"][:, :, :].values
         )
     P_int = xr.DataArray(
         data=pressure_i,

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -195,8 +195,8 @@ def _calc_pressure(dset):
     if not all(pvar in list(dset.keys()) for pvar in presvars):
         raise KeyError(
             "The model does not have the variables to calculate"
-            "the pressure. This can be done either with PMID or with"
-            "P0, PS, hyam and hybm."
+            "the pressure. This can be done either with PMID or with "
+            "P0, PS, hyam and hybm. "
             "If the vertical coordinate is not needed, set surface_only=True"
         )
     time = dset["PS"].time.values

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -68,17 +68,20 @@ def open_mfdataset(
     if not surf_only:
         if "PMID" not in dset_load.keys():
             dset_load["PMID"] = _calc_pressure(dset_load)
-        var_list = var_list + ["pres_pa_mid"]
         if "Z3" not in dset_load.keys():
             warnings.warn("Geopotential height Z3 is not in model keys. Assuming hydrostatic runs")
             dset_load["Z3"] = _calc_hydrostatic_height(dset_load)
-        var_list = var_list + ["alt_msl_m_mid"]
 
         # calc layer thickness if hyai and hybi exist
         if {"hyai", "hybi"} <= dset_load.keys():
             dset_load["pres_pa_int"] = _calc_pressure_i(dset_load)
             dset_load["dz_m"] = _calc_layer_thickness_i(dset_load)
             var_list.append("dz_m")
+        else:
+            print(
+                "The model dataset does not contain 'hyai' or 'hybi'."
+                "Skipping layer thickness calculations (dz_m)."
+            )
 
         dset_load = dset_load.rename(
             {
@@ -192,9 +195,9 @@ def _calc_pressure(dset):
     if not all(pvar in list(dset.keys()) for pvar in presvars):
         raise KeyError(
             "The model does not have the variables to calculate"
-            + "the pressure. This can be done either with PMID or with"
-            + "P0, PS, hyam and hybm.\n"
-            + "If the vertical coordinate is not needed, set surface_only=True"
+            "the pressure. This can be done either with PMID or with"
+            "P0, PS, hyam and hybm."
+            "If the vertical coordinate is not needed, set surface_only=True"
         )
     time = dset["PS"].time.values
     vert = dset["hyam"].lev.values
@@ -380,8 +383,7 @@ def _calc_layer_thickness_i(dset):
     Note: This calculates based on pressure being in increasing order,
     and altitude in decreasing order. The code flips all the variables
     along the 'z' dimensions at the end. 'pres_pa_int' does not
-    because it has a dimension of 'ilev' instead of 'z'. Add a correction
-    for this last part.
+    because it has a dimension of 'ilev' instead of 'z'.
 
     Parameters
     ----------

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -194,7 +194,7 @@ def _calc_pressure(dset):
     presvars = ["PS", "hyam", "hybm"]
     if not all(pvar in list(dset.keys()) for pvar in presvars):
         raise KeyError(
-            "The model does not have the variables to calculate"
+            "The model does not have the variables to calculate "
             "the pressure. This can be done either with PMID or with "
             "P0, PS, hyam and hybm. "
             "If the vertical coordinate is not needed, set surface_only=True"

--- a/monetio/models/_cesm_fv_mm.py
+++ b/monetio/models/_cesm_fv_mm.py
@@ -6,6 +6,10 @@ import numpy as np
 import xarray as xr
 from numpy import meshgrid
 
+# -- TO DO:
+# need to have the code be able to read additional variables when surf_only = false
+# currently does it when its true .. can base it off of if not surf_only section
+
 
 def open_mfdataset(
     fname,
@@ -72,7 +76,7 @@ def open_mfdataset(
             warnings.warn("Geopotential height Z3 is not in model keys. Assuming hydrostatic runs")
             dset_load["Z3"] = _calc_hydrostatic_height(dset_load)
         if "PS" in dset_load.keys():
-            dset_load["PS"].rename("pres_pa_mid")
+            dset_load["PS"].rename("surfpres_pa")
         else:
             warnings.warn("Surface pressure (PS) is not in model keys. Continuing without it.")
         if "PHIS" in dset_load.keys():
@@ -99,12 +103,10 @@ def open_mfdataset(
                 "calculation at the interface, or 'PDELDDRY' for calculation using midlayer. "
                 "Skipping layer thickness calculations (dz_m)."
             )
-
         dset_load = dset_load.rename(
             {
                 "T": "temperature_k",
                 "Z3": "alt_msl_m_mid",
-                # "PS": "surfpres_pa",
                 "PMID": "pres_pa_mid",
             }
         )

--- a/tests/test_cesm_fv_updated.py
+++ b/tests/test_cesm_fv_updated.py
@@ -159,7 +159,6 @@ def test_open_mfdataset_surf_only_false(test_file_path):
 def test_hybrid_vars(test_file_path):
     file_path = str(test_file_path)
     ds = xr.open_mfdataset(file_path)
-
     assert "hyam" in ds.variables, "hyam variable is missing. "
     assert tuple(ds["hyam"].dims) == ("lev",), "Dimensions for hyam are incorrect. "
     assert "hybm" in ds.variables, "hybm variable is missing. "
@@ -174,7 +173,6 @@ def test_calc_pressure(test_file_path):
     file_path = str(test_file_path)
     ds = xr.open_mfdataset(file_path)
     pressure = _calc_pressure(ds)
-
     assert tuple(pressure.dims) == (
         "time",
         "lev",

--- a/tests/test_cesm_fv_updated.py
+++ b/tests/test_cesm_fv_updated.py
@@ -143,8 +143,9 @@ def test_open_mfdataset(test_file_path):
 
 
 def test_open_mfdataset_surf_only_false(test_file_path):
+    file_path = str(test_file_path)
     var_list = ["NO2"]
-    ds = open_mfdataset(test_file_path, var_list=var_list, surf_only=False)
+    ds = open_mfdataset(file_path, var_list=var_list, surf_only=False)
     _check_dimensions(ds)
     _check_latitude_and_longitude(ds)
     _check_time(ds)
@@ -156,7 +157,8 @@ def test_open_mfdataset_surf_only_false(test_file_path):
 
 
 def test_hybrid_vars(test_file_path):
-    ds = xr.open_mfdataset(test_file_path)
+    file_path = str(test_file_path)
+    ds = xr.open_mfdataset(file_path)
 
     assert "hyam" in ds.variables, "hyam variable is missing. "
     assert tuple(ds["hyam"].dims) == ("lev",), "Dimensions for hyam are incorrect. "

--- a/tests/test_cesm_fv_updated.py
+++ b/tests/test_cesm_fv_updated.py
@@ -1,0 +1,210 @@
+import shutil
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+from filelock import FileLock
+
+from monetio.models._cesm_fv_mm import _calc_pressure, _calc_pressure_i, open_mfdataset
+
+HERE = Path(__file__).parent
+
+
+def retrieve_test_file():
+    # fn = "CAM_chem_merra2_FCSD_1deg_QFED_world_201909-01-09_small_sfc.nc"
+    fn = "CAM_chem_merra2_FCSD_1deg_QFED_world_201909-01-09_small.nc"
+
+    # Download to tests/data if not already present
+    p = HERE / "data" / fn
+    if not p.is_file():
+        warnings.warn(f"Downloading test file {fn} for CESM-FV test")
+        import requests
+
+        r = requests.get(
+            "https://csl.noaa.gov/groups/csl4/modeldata/melodies-monet/data/"
+            + f"example_model_data/cesmfv_example/{fn}",
+            stream=True,
+        )
+        r.raise_for_status()
+        with open(p, "wb") as f:
+            f.write(r.content)
+
+    return p
+
+
+@pytest.fixture(scope="module")
+def test_file_path(tmp_path_factory, worker_id=None):
+    worker_id = "master"
+
+    if worker_id == "master":
+        # Not executing with multiple workers;
+        # let pytest's fixture caching do its job
+        return retrieve_test_file()
+
+    # Get the temp directory shared by all workers
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+
+    # Copy to the shared test location
+    p_test = root_tmp_dir / "cesm_fv_test.nc"
+    with FileLock(p_test.as_posix() + ".lock"):
+        if p_test.is_file():
+            return p_test
+        else:
+            p = retrieve_test_file()
+            shutil.copy(p, p_test)
+            return p_test
+
+
+def _check_dimensions(ds):
+    assert set(ds.dims) == {"time", "x", "y", "z"}
+
+
+def _check_latitude_and_longitude(ds):
+    assert "lat" not in ds.variables
+    assert "lon" not in ds.variables
+    assert "latitude" in ds.coords
+    assert "longitude" in ds.coords
+    assert np.all(ds.latitude.values[0, :] == ds.latitude.values[0, 0])
+    assert np.all(ds.longitude.values[:, 0] == ds.longitude.values[0, 0])
+    assert np.all(ds.latitude.values >= -90) and np.all(
+        ds.latitude.values <= 90
+    ), "Latitude values are out of range. "
+    assert np.all(ds.longitude.values >= -180) and np.all(
+        ds.longitude.values <= 180
+    ), "Longitude values are out of range. "
+
+
+def _check_time(ds):
+    assert "time" in ds.coords, "Time coordinate is missing. "
+    assert len(ds.time) > 0, "Time dimension is empty. "
+
+
+def _check_species_variables(ds):
+    species_list = ["O3", "NO2"]
+    for sp in species_list:
+        if sp in ds.variables:
+            assert sp in ds.variables, f"{sp} variable is missing. "
+            assert tuple(ds[sp].dims) == (
+                "time",
+                "z",
+                "y",
+                "x",
+            ), f"Dimensions for {sp} are incorrect. "
+            assert ds[sp].attrs["units"] == "ppbv", f"Units for {sp} are incorrect. "
+
+
+def _check_vertical_levels(ds):
+    assert np.all(np.diff(ds["z"].values) > 0), "Vertical levels are not flipped correctly. "
+
+
+def _check_pressure_vars(ds):
+    assert "surfpres_pa" in ds.variables, "surfpres_pa variable is missing. "
+    assert tuple(ds["surfpres_pa"].dims) == (
+        "time",
+        "y",
+        "x",
+    ), "Dimensions for surfpres_pa are incorrect. "
+    assert ds["surfpres_pa"].attrs["units"] == "Pa", "Units for surfpres_pa are incorrect. "
+    assert "pres_pa_mid" in ds.variables, "pres_pa_mid variable is missing. "
+    assert tuple(ds["pres_pa_mid"].dims) == (
+        "time",
+        "z",
+        "y",
+        "x",
+    ), "Dimensions for pres_pa_mid are incorrect. "
+    assert ds["pres_pa_mid"].attrs["units"] == "Pa", "Units for pres_pa_mid are incorrect. "
+
+
+def _check_temperature(ds):
+    assert "temperature_k" in ds.variables, "temperature_k variable is missing. "
+    assert tuple(ds["temperature_k"].dims) == (
+        "time",
+        "z",
+        "y",
+        "x",
+    ), "Dimensions for temperature_k are incorrect. "
+    assert ds["temperature_k"].attrs["units"] == "K", "Units for temperature_k are incorrect. "
+
+
+def _check_altitude(ds):
+    assert "alt_msl_m_mid" in ds.variables, "alt_msl_m_mid variable is missing. "
+    assert tuple(ds["alt_msl_m_mid"].dims) == (
+        "time",
+        "z",
+        "y",
+        "x",
+    ), "Dimensions for alt_msl_m_mid are incorrect. "
+    assert ds["alt_msl_m_mid"].attrs["units"] == "m", "Units for alt_msl_m_mid are incorrect. "
+    assert "alt_agl_m_mid" in ds.variables, "alt_agl_m_mid variable is missing. "
+    assert tuple(ds["alt_agl_m_mid"].dims) == (
+        "time",
+        "z",
+        "y",
+        "x",
+    ), "Dimensions for alt_agl_m_mid are incorrect. "
+    assert ds["alt_agl_m_mid"].attrs["units"] == "m", "Units for alt_agl_m_mid are incorrect. "
+
+
+def test_open_mfdataset(test_file_path):
+    file_path = str(test_file_path)
+    ds = open_mfdataset(file_path)
+    _check_dimensions(ds)
+    _check_latitude_and_longitude(ds)
+    _check_time(ds)
+    _check_species_variables(ds)
+    _check_vertical_levels(ds)
+
+
+def test_open_mfdataset_surf_only_false(test_file_path):
+    var_list = ["NO2"]
+    ds = open_mfdataset(test_file_path, var_list=var_list, surf_only=False)
+    _check_dimensions(ds)
+    _check_latitude_and_longitude(ds)
+    _check_time(ds)
+    _check_species_variables(ds)
+    _check_vertical_levels(ds)
+    _check_pressure_vars(ds)
+    _check_temperature(ds)
+    _check_altitude(ds)
+
+
+def test_hybrid_vars(test_file_path):
+    ds = xr.open_mfdataset(test_file_path)
+
+    assert "hyam" in ds.variables, "hyam variable is missing. "
+    assert tuple(ds["hyam"].dims) == ("lev",), "Dimensions for hyam are incorrect. "
+    assert "hybm" in ds.variables, "hybm variable is missing. "
+    assert tuple(ds["hybm"].dims) == ("lev",), "Dimensions for hybm are incorrect. "
+    assert "hyai" in ds.variables, "hyai variable is missing. "
+    assert tuple(ds["hyai"].dims) == ("ilev",), "Dimensions for hyai are incorrect. "
+    assert "hybi" in ds.variables, "hybi variable is missing. "
+    assert tuple(ds["hybi"].dims) == ("ilev",), "Dimensions for hybi are incorrect. "
+
+
+def test_calc_pressure(test_file_path):
+    file_path = str(test_file_path)
+    ds = xr.open_mfdataset(file_path)
+    pressure = _calc_pressure(ds)
+
+    assert tuple(pressure.dims) == (
+        "time",
+        "lev",
+        "lat",
+        "lon",
+    ), "Dimensions for pressure are incorrect. "
+    assert pressure.attrs["units"] == "Pa", "Units for pressure are incorrect. "
+
+
+def test_calc_pressure_i(test_file_path):
+    file_path = str(test_file_path)
+    ds = xr.open_mfdataset(file_path)
+    pressure_i = _calc_pressure_i(ds)
+    assert tuple(pressure_i.dims) == (
+        "time",
+        "ilev",
+        "lat",
+        "lon",
+    ), "Dimensions for pressure are incorrect. "
+    assert pressure_i.attrs["units"] == "Pa", "Units for pressure are incorrect. "

--- a/tests/test_cesm_fv_updated.py
+++ b/tests/test_cesm_fv_updated.py
@@ -149,7 +149,8 @@ def _check_altitude(ds):
 
 def test_open_mfdataset(test_file_path):
     file_path = str(test_file_path)
-    ds = open_mfdataset(file_path)
+    var_list = ["NO2"]
+    ds = open_mfdataset(file_path, var_list=var_list)
     _check_dimensions(ds)
     _check_latitude_and_longitude(ds)
     _check_time(ds)

--- a/tests/test_cesm_fv_updated.py
+++ b/tests/test_cesm_fv_updated.py
@@ -13,8 +13,7 @@ HERE = Path(__file__).parent
 
 
 def retrieve_test_file():
-    # fn = "CAM_chem_merra2_FCSD_1deg_QFED_world_201909-01-09_small_sfc.nc"
-    fn = "CAM_chem_merra2_FCSD_1deg_QFED_world_201909-01-09_small.nc"
+    fn = "f.e22.FCnudged.f09_f09_mg17.cst_emis.cam.h1.2018-12-25-43200.nc"
 
     # Download to tests/data if not already present
     p = HERE / "data" / fn

--- a/tests/test_cesm_fv_updated.py
+++ b/tests/test_cesm_fv_updated.py
@@ -100,13 +100,6 @@ def _check_vertical_levels(ds):
 
 
 def _check_pressure_vars(ds):
-    assert "surfpres_pa" in ds.variables, "surfpres_pa variable is missing. "
-    assert tuple(ds["surfpres_pa"].dims) == (
-        "time",
-        "y",
-        "x",
-    ), "Dimensions for surfpres_pa are incorrect. "
-    assert ds["surfpres_pa"].attrs["units"] == "Pa", "Units for surfpres_pa are incorrect. "
     assert "pres_pa_mid" in ds.variables, "pres_pa_mid variable is missing. "
     assert tuple(ds["pres_pa_mid"].dims) == (
         "time",
@@ -137,14 +130,6 @@ def _check_altitude(ds):
         "x",
     ), "Dimensions for alt_msl_m_mid are incorrect. "
     assert ds["alt_msl_m_mid"].attrs["units"] == "m", "Units for alt_msl_m_mid are incorrect. "
-    assert "alt_agl_m_mid" in ds.variables, "alt_agl_m_mid variable is missing. "
-    assert tuple(ds["alt_agl_m_mid"].dims) == (
-        "time",
-        "z",
-        "y",
-        "x",
-    ), "Dimensions for alt_agl_m_mid are incorrect. "
-    assert ds["alt_agl_m_mid"].attrs["units"] == "m", "Units for alt_agl_m_mid are incorrect. "
 
 
 def test_open_mfdataset(test_file_path):


### PR DESCRIPTION
I made some updates to the CESM-FV reader to have the capability to calculate the layer thickness (dz_m) if the interface pressures (hyai, hybi) are provided in the model output. The script will now calculate the variable, 'pres_pa_int', and use this variable to calculate the interface layer height, which is then used to calculate the layer thickness. These calculations are based on the default vertical structure of CESM, where the pressure is in increasing order and altitude in decreasing order. Once this is calculated, the script reorders the vertical levels so that the surface is first. This is done by default in the original code, but I added a line so that 'pres_pa_int' is also treated this way, as the original code does this based on vertical dimension 'z', which is not what is used for 'pres_pa_int' since it has an extra vertical level (33 instead of 32). 'pres_pa_int' has a vertical dimension called 'ilev'. This is currently only used in the CESM_FV reader, but is saved in the processed dataset. Moving forward, if needed, renaming the 'ilev' dimension to something like 'z_i' may be more consistent with the monetio/melodies-monet formatting, but not necessary for now. 

In addition to this, the pyresample dependency was removed and now deals with the wrap longitudes using numpy.   