### PR TITLE
Simple bugfix: PM2.5 should be dry

### DIFF
--- a/monetio/models/_camx_mm.py
+++ b/monetio/models/_camx_mm.py
@@ -641,7 +641,6 @@ fine = np.array(
         "PSO4",
         "PNO3",
         "PNH4",
-        "PH2O",
         "PCL",
         "PEC",
         "FPRM",


### PR DESCRIPTION
Measurements are always in dry PM2.5, the current code used wet.
This PR fixes that by removing a single line of code, which included PH2O in the particulate matter.
Cheers
Pablo