### PR TITLE
Drop the Python 3.6 and 3.8 CI cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'noaa-oar-arl/monetio'
     strategy:
       matrix:
-        python-version: ["3.6", "3.8", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:
         shell: bash -l {0}
@@ -27,25 +27,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python (micromamba) [>3.6]
-        if: matrix.python-version != '3.6'
+      - name: Set up Python (micromamba)
         uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment-dev.yml
           cache-environment: true
           create-args: >-
             python=${{ matrix.python-version }}
-
-      - name: Set up Python (micromamba) [3.6]
-        if: matrix.python-version == '3.6'
-        uses: mamba-org/setup-micromamba@v2
-        with:
-          environment-file: environment-dev.yml
-          cache-environment: true
-          create-args: >-
-            python=${{ matrix.python-version }}
-            attrs=22.2.0
-            aioitertools=0.11.0
 
       - name: Test with pytest
         run: pytest -n auto --dist loadgroup -v -ra -W "ignore:Downloading test file:UserWarning::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'noaa-oar-arl/monetio'
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
in favor of [the current conda-forge pythons](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/0d09990630d8add9cd575d7c39a369da7bdc0cd9/recipe/conda_build_config.yaml#L834) (except 3.12, since we're still using `pandas<2`).

In some recent CI runs, although 3.6 is still working, the 3.8 env is failing to solve. Probably we could get it working again by determining a proper set of pins, but might as well drop it since 3.8 is [end-of-life](https://devguide.python.org/versions/) anyway.

The feedstock was already [updated](https://github.com/conda-forge/monetio-feedstock/pull/12) to `python >={{ python_min }}`, which [is currently 3.9](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/0d09990630d8add9cd575d7c39a369da7bdc0cd9/recipe/conda_build_config.yaml#L846).

xref: #170