### PR TITLE
OpenAQ web API v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs/api/
 tests/data/MOP*.he5
 tests/data/TROPOMI*.nc
 tests/data/OMPS-*.h5
+monetio/obs/openaq_locations_data.json
 
 # Default GitHub .gitignore for Python below:
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ docs/api/
 tests/data/MOP*.he5
 tests/data/TROPOMI*.nc
 tests/data/OMPS-*.h5
-monetio/obs/openaq_locations_data.json
+monetio/obs/openaq_locations_data.*
 
 # Default GitHub .gitignore for Python below:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         exclude: tdump\.[0-9]*
       - id: end-of-file-fixer
       - id: check-docstring-first
-        exclude: monetio/obs/openaq_v2\.py
+        exclude: monetio/obs/openaq_v(2|3)\.py
       - id: check-yaml
 
   - repo: https://github.com/asottile/pyupgrade

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -15,6 +15,7 @@ dependencies:
   - xarray
   #
   # optional
+  - filelock
   - h5netcdf
   - h5py
   - joblib
@@ -25,7 +26,6 @@ dependencies:
   - timezonefinder
   #
   # test
-  - filelock
   - pytest
   - pytest-xdist
   #

--- a/monetio/__init__.py
+++ b/monetio/__init__.py
@@ -12,6 +12,7 @@ from .obs import (
     nadp,
     openaq,
     openaq_v2,
+    openaq_v3,
     pams,
 )
 from .profile import geoms, gml_ozonesonde, icartt, tolnet
@@ -43,6 +44,7 @@ __all__ = [
     "nadp",
     "openaq",
     "openaq_v2",
+    "openaq_v3",
     "pams",
     #
     # profile obs

--- a/monetio/obs/__init__.py
+++ b/monetio/obs/__init__.py
@@ -11,6 +11,7 @@ from . import (
     nadp,
     openaq,
     openaq_v2,
+    openaq_v3,
     pams,
 )
 
@@ -27,6 +28,7 @@ __all__ = [
     "nadp",
     "openaq",
     "openaq_v2",
+    "openaq_v3",
     "pams",
 ]
 

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -1,0 +1,611 @@
+"""Get AQ data from the OpenAQ v2 REST API.
+
+Visit https://docs.openaq.org/docs/getting-started to get an API key
+and set environment variable ``OPENAQ_API_KEY`` to use it.
+
+For example, in Bash:
+
+.. code-block:: bash
+
+   export OPENAQ_API_KEY="your_api_key_here"
+
+https://openaq.org/
+
+https://api.openaq.org/docs#/v2
+"""
+
+import functools
+import json
+import logging
+import os
+import warnings
+
+import numpy as np
+import pandas as pd
+import requests
+
+logger = logging.getLogger(__name__)
+
+API_KEY = os.environ.get("OPENAQ_API_KEY", None)
+if API_KEY is not None:
+    API_KEY = API_KEY.strip()
+    if len(API_KEY) != 64:
+        warnings.warn(f"API key length is {len(API_KEY)}, expected 64")
+
+_PPM_TO_UGM3 = {
+    "o3": 1990,
+    "co": 1160,
+    "no2": 1900,
+    "no": 1240,
+    "so2": 2650,
+    "ch4": 664,
+    "co2": 1820,
+}
+"""Conversion factors from ppmv to µg/m³.
+
+Based on
+
+- air average molecular weight: 29 g/mol
+- air density: 1.2 kg m -3
+
+and rounded to 3 significant figures.
+"""
+
+# NOx assumption
+_PPM_TO_UGM3["nox"] = _PPM_TO_UGM3["no2"]
+
+_NON_MOLEC_PARAMS = [
+    "pm1",
+    "pm25",
+    "pm4",
+    "pm10",
+    "bc",
+]
+"""Parameters that are not molecules and should be in µg/m³ units."""
+
+
+def _api_key_warning(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if API_KEY is None:
+            warnings.warn(
+                "Non-cached requests to the OpenAQ v2 web API will be slow without an API key "
+                "or requests will fail (HTTP error 401). "
+                "Obtain one (https://docs.openaq.org/docs/getting-started#api-key) "
+                "and set your OPENAQ_API_KEY environment variable.",
+                stacklevel=2,
+            )
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+_BASE_URL = "https://api.openaq.org"
+_ENDPOINTS = {
+    "locations": "/v2/locations",
+    "parameters": "/v2/parameters",
+    "measurements": "/v2/measurements",
+}
+
+
+def _consume(endpoint, *, params=None, timeout=10, retry=5, limit=500, npages=None):
+    """Consume a paginated OpenAQ API endpoint.
+
+    Parameters
+    ----------
+    endpoint : str
+        API endpoint, e.g. ``'/v2/locations'``, ``'/v2/parameters'``, ``'/v2/measurements'``.
+    params : dict, optional
+        Parameters for the GET request to the API.
+        Don't pass ``limit``, ``page``, or ``offset`` here, since they are covered
+        by the `limit` and `npages` kwargs.
+    timeout : float or tuple
+        Seconds to wait for the server before giving up. Passed to ``requests.get``.
+    retry : int
+        Number of times to retry the request if it times out.
+    limit : int
+        Max number of results per page.
+    npages : int, optional
+        Number of pages to fetch.
+        By default, try to fetch as many as needed to get all results.
+    """
+    import time
+    from random import random as rand
+
+    if not endpoint.startswith("/"):
+        endpoint = "/" + endpoint
+    if not endpoint.startswith("/v2"):
+        endpoint = "/v2" + endpoint
+    url = _BASE_URL + endpoint
+
+    if params is None:
+        params = {}
+
+    if npages is None:
+        # Maximize
+        # "limit + offset must be <= 100_000"
+        # where offset = limit * (page - 1)
+        # => limit * page <= 100_000
+        # and also page must be <= 6_000
+        npages = min(100_000 // limit, 6_000)
+
+    params["limit"] = limit
+
+    headers = {
+        "Accept": "application/json",
+        "X-API-Key": API_KEY,
+        "User-Agent": "monetio",
+    }
+
+    data = []
+    for page in range(1, npages + 1):
+        params["page"] = page
+
+        tries = 0
+        while tries < retry:
+            logger.debug(f"GET {url} params={params}")
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
+            tries += 1
+            if r.status_code == 408:
+                logger.info(f"request timed out (try {tries}/{retry})")
+                time.sleep(tries + 0.1 * rand())
+            elif r.status_code == 429:
+                # Note: response headers don't seem to include Retry-After
+                logger.info(f"rate limited (try {tries}/{retry})")
+                time.sleep(tries * 5 + 0.2 * rand())
+            else:
+                break
+        r.raise_for_status()
+
+        this_data = r.json()
+        found = this_data["meta"]["found"]
+        n = len(this_data["results"])
+        logger.info(f"page={page} found={found!r} n={n}")
+        if n == 0:
+            break
+        if n < limit:
+            logger.info(f"note: results returned ({n}) < limit ({limit})")
+        data.extend(this_data["results"])
+
+    if isinstance(found, str) and found.startswith(">"):
+        print(f"warning: some query results not fetched ('found' is {found!r})")
+    elif isinstance(found, int) and len(data) < found:
+        print(f"warning: some query results not fetched (found={found}, got {len(data)} results)")
+
+    return data
+
+
+@_api_key_warning
+def get_locations(**kwargs):
+    """Get available site info (including site IDs) from OpenAQ v2 API.
+
+    kwargs are passed to :func:`_consume`.
+
+    https://api.openaq.org/docs#/v2/locations_get_v2_locations_get
+    """
+
+    data = _consume(_ENDPOINTS["locations"], **kwargs)
+
+    # Some fields with scalar values to take
+    some_scalars = [
+        "id",
+        "name",
+        "city",
+        "country",
+        # "entity",  # all null (from /measurements we do get values)
+        "isMobile",
+        # "isAnalysis",  # all null
+        # "sensorType",  # all null (from /measurements we do get values)
+        "firstUpdated",
+        "lastUpdated",
+    ]
+
+    data2 = []
+    for d in data:
+        lat = d["coordinates"]["latitude"]
+        lon = d["coordinates"]["longitude"]
+        parameters = [p["parameter"] for p in d["parameters"]]
+        mfs = d["manufacturers"]
+        if mfs:
+            manufacturer = mfs[0]["manufacturerName"]
+            if len(mfs) > 1:
+                logger.info(f"site {d['id']} has multiple manufacturers: {mfs}")
+        else:
+            manufacturer = None
+        d2 = {k: d[k] for k in some_scalars}
+        d2.update(
+            latitude=lat,
+            longitude=lon,
+            parameters=parameters,
+            manufacturer=manufacturer,
+        )
+        data2.append(d2)
+
+    df = pd.DataFrame(data2)
+
+    # Compute datetimes (the timestamps are already in UTC, but with tz specified)
+    assert df.firstUpdated.str.slice(-6, None).eq("+00:00").all()
+    df["firstUpdated"] = pd.to_datetime(df.firstUpdated.str.slice(0, -6))
+    assert df.lastUpdated.str.slice(-6, None).eq("+00:00").all()
+    df["lastUpdated"] = pd.to_datetime(df.lastUpdated.str.slice(0, -6))
+
+    # Site ID
+    df = df.rename(columns={"id": "siteid"})
+    df["siteid"] = df.siteid.astype(str)
+    maybe_dupe_rows = df[df.siteid.duplicated(keep=False)].sort_values("siteid")
+    if not maybe_dupe_rows.empty:
+        logger.info(
+            f"note: found {len(maybe_dupe_rows)} rows with duplicate site IDs:\n{maybe_dupe_rows}"
+        )
+    df = df.drop_duplicates("siteid", keep="first").reset_index(drop=True)  # seem to be some dupes
+
+    return df
+
+
+def get_parameters(**kwargs):
+    """Get supported parameter info from OpenAQ v2 API.
+
+    kwargs are passed to :func:`_consume`.
+    """
+
+    data = _consume(_ENDPOINTS["parameters"], **kwargs)
+
+    df = pd.DataFrame(data)
+
+    return df
+
+
+def get_latlonbox_sites(latlonbox, **kwargs):
+    """From all available sites, return those within a lat/lon box.
+
+    kwargs are passed to :func:`_consume`.
+
+    Parameters
+    ----------
+    latlonbox : array-like of float
+        ``[lat1, lon1, lat2, lon2]`` (lower-left corner, upper-right corner)
+    """
+    lat1, lon1, lat2, lon2 = latlonbox
+    sites = get_locations(**kwargs)
+
+    in_box = (
+        (sites.latitude >= lat1)
+        & (sites.latitude <= lat2)
+        & (sites.longitude >= lon1)
+        & (sites.longitude <= lon2)
+    )
+    # TODO: need to account for case of box crossing antimeridian
+
+    return sites[in_box].reset_index(drop=True)
+
+
+@_api_key_warning
+def add_data(
+    dates,
+    *,
+    parameters=None,
+    country=None,
+    search_radius=None,
+    sites=None,
+    entity=None,
+    sensor_type=None,
+    query_time_split="1H",
+    wide_fmt=False,  # FIXME: probably want to default to True
+    **kwargs,
+):
+    """Get OpenAQ API v2 data, including low-cost sensors.
+
+    Parameters
+    ----------
+    dates : datetime-like or array-like of datetime-like
+        One desired date/time or
+        an array, of which the min and max will be used
+        as inclusive time bounds of the desired data.
+    parameters : str or list of str, optional
+        For example, ``'o3'`` or ``['pm25', 'o3']`` (default).
+    country : str or list of str, optional
+        For example, ``'US'`` or ``['US', 'CA']`` (two-letter country codes).
+        Default: full dataset (no limitation by country).
+    search_radius : dict, optional
+        Mapping of coords tuple (lat, lon) [deg] to search radius [m] (max of 25 km).
+        For example: ``search_radius={(39.0, -77.0): 10_000}``.
+        Note that this dict can contain multiple entries.
+    sites : list of str, optional
+        Site ID(s) to include, e.g. a specific known site
+        or group of sites from :func:`get_latlonbox_sites`.
+        Default: full dataset (no limitation by site).
+    entity : str or list of str, optional
+        Options: ``'government'``, ``'research'``, ``'community'``.
+        Default: full dataset (no limitation by entity).
+    sensor_type : str or list of str, optional
+        Options: ``'low-cost sensor'``, ``'reference grade'``.
+        Default: full dataset (no limitation by sensor type).
+    query_time_split
+        Frequency to use when splitting the web API queries in time,
+        in a format that ``pandas.to_timedelta`` will understand.
+        This is necessary since there is a 100k limit on the number of results.
+        However, if you are using search radii, e.g., you may want to set this
+        to something higher in order to increase the query return speed.
+        Set to ``None`` for no time splitting.
+        Default: 1 hour
+        (OpenAQ data are hourly, so setting to something smaller won't help).
+        Ignored if only one date/time is provided.
+    wide_fmt : bool
+        Convert dataframe to wide format (one column per parameter).
+        Note that for some variables that involves conversion from
+        µg/m³ to ppmv.
+        This conversion is based on an average air molecular weight of 29 g/mol
+        and an air density of 1.2 kg/m³.
+        Use ``wide_fmt=False`` if you want to do the conversion yourself.
+        In some cases, the conversion to wide format also reduces the amount of data returned.
+    retry : int, default: 5
+        Number of times to retry an API request if it times out.
+    timeout : float, default: 10
+        Seconds to wait for the server before giving up, for a single request.
+    threads : int, optional
+        Number of threads to use for fetching data.
+        Default: no multi-threading.
+    """
+
+    dates = pd.to_datetime(dates)
+    if pd.api.types.is_scalar(dates):
+        dates = pd.DatetimeIndex([dates])
+    dates = dates.dropna()
+    if dates.empty:
+        raise ValueError("must provide at least one datetime-like")
+
+    if parameters is None:
+        parameters = ["pm25", "o3"]
+    elif isinstance(parameters, str):
+        parameters = [parameters]
+
+    query_dt = pd.to_timedelta(query_time_split) if len(dates) > 1 else None
+    date_min, date_max = dates.min(), dates.max()
+    if query_dt is not None:
+        if query_dt <= pd.Timedelta(0):
+            raise ValueError(
+                f"query_time_split must be positive, got {query_dt} from {query_time_split!r}"
+            )
+        if date_min == date_max:
+            raise ValueError(
+                "must provide at least two unique datetimes to use query_time_split. "
+                "Set query_time_split=None to disable time splitting."
+            )
+
+    if search_radius is not None:
+        for coords, radius in search_radius.items():
+            if not 0 < radius <= 25_000:
+                raise ValueError(
+                    f"invalid radius {radius!r} for location {coords!r}. "
+                    "Must be positive and <= 25000 (25 km)."
+                )
+
+    def iter_time_slices():
+        # seems that (from < time <= to) == (from , to] is used
+        # i.e. `from` is exclusive, `to` is inclusive
+        one_sec = pd.Timedelta(seconds=1)
+        if query_dt is not None:
+            t = date_min
+            while t < date_max:
+                t_next = min(t + query_dt, date_max)
+                yield t - one_sec, t_next
+                t = t_next
+        else:
+            yield date_min - one_sec, date_max
+
+    base_params = {}
+    if country is not None:
+        base_params.update(country=country)
+    if sites is not None:
+        base_params.update(location_id=sites)
+    if entity is not None:
+        base_params.update(entity=entity)
+    if sensor_type is not None:
+        base_params.update(sensor_type=sensor_type)
+
+    def iter_queries():
+        for parameter in parameters:
+            for t_from, t_to in iter_time_slices():
+                if search_radius is not None:
+                    for coords, radius in search_radius.items():
+                        lat, lon = coords
+                        yield {
+                            **base_params,
+                            "parameter": parameter,
+                            "date_from": t_from,
+                            "date_to": t_to,
+                            "coordinates": f"{lat:.8f},{lon:.8f}",
+                            "radius": radius,
+                        }
+                else:
+                    yield {
+                        **base_params,
+                        "parameter": parameter,
+                        "date_from": t_from,
+                        "date_to": t_to,
+                    }
+
+    threads = kwargs.pop("threads", None)
+    if threads is not None:
+        import concurrent.futures
+        from itertools import chain
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor:
+            data = chain.from_iterable(
+                executor.map(
+                    lambda params: _consume(_ENDPOINTS["measurements"], params=params, **kwargs),
+                    iter_queries(),
+                )
+            )
+    else:
+        data = []
+        for params in iter_queries():
+            this_data = _consume(
+                _ENDPOINTS["measurements"],
+                params=params,
+                **kwargs,
+            )
+            data.extend(this_data)
+
+    df = pd.DataFrame(data)
+    if df.empty:
+        print("warning: no data found")
+        return df
+
+    #  #   Column       Non-Null Count  Dtype
+    # ---  ------       --------------  -----
+    #  0   locationId   2000 non-null   int64
+    #  1   location     2000 non-null   object
+    #  2   parameter    2000 non-null   object
+    #  3   value        2000 non-null   float64
+    #  4   date         2000 non-null   object
+    #  5   unit         2000 non-null   object
+    #  6   coordinates  2000 non-null   object
+    #  7   country      2000 non-null   object
+    #  8   city         0 non-null      object  # None
+    #  9   isMobile     2000 non-null   bool
+    #  10  isAnalysis   0 non-null      object  # None
+    #  11  entity       2000 non-null   object
+    #  12  sensorType   2000 non-null   object
+
+    to_expand = ["date", "coordinates"]
+    new = pd.json_normalize(json.loads(df[to_expand].to_json(orient="records")))
+
+    time = pd.to_datetime(new["date.utc"]).dt.tz_localize(None)
+    # utcoffset = pd.to_timedelta(new["date.local"].str.slice(-6, None) + ":00")
+    # time_local = time + utcoffset
+    # ^ Seems some have negative minutes in the tz, so this method complains
+    time_local = pd.to_datetime(new["date.local"].str.slice(0, 19))
+    utcoffset = time_local - time
+
+    # TODO: null case??
+    lat = new["coordinates.latitude"]
+    lon = new["coordinates.longitude"]
+
+    df = df.drop(columns=to_expand).assign(
+        time=time,
+        time_local=time_local,
+        utcoffset=utcoffset,
+        latitude=lat,
+        longitude=lon,
+    )
+
+    # Rename columns and ensure site ID is string
+    df = df.rename(
+        columns={
+            "locationId": "siteid",
+            "isMobile": "is_mobile",
+            "isAnalysis": "is_analysis",
+            "sensorType": "sensor_type",
+        },
+    )
+    df["siteid"] = df.siteid.astype(str)
+
+    # Most variables invalid if < 0
+    # > preferredUnit.value_counts()
+    # ppb              19
+    # µg/m³            13
+    # ppm              10
+    # particles/cm³     8
+    # %                 3  relative humidity
+    # umol/mol          1
+    # ng/m3             1
+    # deg               1  wind direction
+    # m/s               1  wind speed
+    # deg_c             1
+    # hpa               1
+    # ugm3              1
+    # c                 1
+    # f                 1
+    # mb                1
+    # iaq               1
+    non_neg_units = [
+        "particles/cm³",
+        "ppm",
+        "ppb",
+        "umol/mol",
+        "µg/m³",
+        "ugm3",
+        "ng/m3",
+        "iaq",
+        #
+        "%",
+        #
+        "m/s",
+        #
+        "hpa",
+        "mb",
+    ]
+    df.loc[df.unit.isin(non_neg_units) & (df.value < 0), "value"] = np.nan
+
+    if wide_fmt:
+        # Normalize units
+        for vn, f in _PPM_TO_UGM3.items():
+            is_ug = (df.parameter == vn) & (df.unit == "µg/m³")
+            df.loc[is_ug, "value"] /= f
+            df.loc[is_ug, "unit"] = "ppm"
+
+        # Warn if inconsistent units
+        p_units = df.groupby("parameter").unit.unique()
+        unique = p_units.apply(len).eq(1)
+        if not unique.all():
+            p_units_non_unique = p_units[~unique]
+            warnings.warn(f"inconsistent units among parameters:\n{p_units_non_unique}")
+
+        # Certain metadata should be unique for a given site but sometimes aren't
+        # (e.g. location names of different specificity, slight differences in lat/lon coords)
+        for col in ["location", "latitude", "longitude"]:
+            site_col = df.groupby("siteid")[col].unique()
+            unique = site_col.apply(len).eq(1)
+            if not unique.all():
+                site_col_non_unique = site_col[~unique]
+                warnings.warn(
+                    f"non-unique {col!r} among site IDs:\n{site_col_non_unique}" "\nUsing first."
+                )
+                df = df.drop(columns=[col]).merge(
+                    site_col.str.get(0),
+                    left_on="siteid",
+                    right_index=True,
+                    how="left",
+                )
+
+        # Pivot
+        index = [
+            "siteid",
+            "time",
+            "latitude",
+            "longitude",
+            "time_local",
+            "utcoffset",
+            #
+            "location",
+            "city",
+            "country",
+            #
+            "entity",
+            "sensor_type",
+            "is_mobile",
+            "is_analysis",
+        ]
+        dupes = df[df.duplicated(keep=False)]
+        if not dupes.empty:
+            logging.info(f"found {len(dupes)} duplicated rows")
+        for col in index:
+            if df[col].isnull().all():
+                index.remove(col)
+                warnings.warn(f"dropping {col!r} from index for wide fmt (all null)")
+        df = (
+            df.drop_duplicates(keep="first")
+            .pivot_table(
+                values="value",
+                index=index,
+                columns="parameter",
+            )
+            .reset_index()
+        )
+
+        # Rename so that units are clear
+        df = df.rename(columns={p: f"{p}_ugm3" for p in _NON_MOLEC_PARAMS}, errors="ignore")
+        df = df.rename(columns={p: f"{p}_ppm" for p in _PPM_TO_UGM3}, errors="ignore")
+
+    return df

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -647,11 +647,13 @@ def add_data(
         raise NotImplementedError  # TODO: not sure what to use for this
     if sensor_type is not None:
         # FIXME: may not be the best approach
-        meta["sensor_type"] = meta["is_monitor"].map(
-            {
-                True: "reference grade",
-                False: "low-cost sensor",
-            }
+        meta = meta.assign(
+            sensor_type=meta["is_monitor"].map(
+                {
+                    True: "reference grade",
+                    False: "low-cost sensor",
+                }
+            )
         )
         meta = meta.query("sensor_type == @sensor_type")
     meta = meta[

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -19,6 +19,7 @@ import logging
 import os
 import warnings
 from pathlib import Path
+from time import perf_counter
 
 import numpy as np
 import pandas as pd
@@ -154,6 +155,7 @@ def _consume(endpoint, *, params=None, timeout=10, retry=5, limit=500, npages=No
                 time.sleep(tries + 0.1 * rand())
             elif r.status_code == 429:
                 # Note: response headers don't seem to include Retry-After
+                # Just `{'detail': 'To many requests'}` in `.json()`
                 logger.info(f"rate limited (try {tries}/{retry})")
                 time.sleep(tries * 5 + 0.2 * rand())
             else:
@@ -166,9 +168,10 @@ def _consume(endpoint, *, params=None, timeout=10, retry=5, limit=500, npages=No
         logger.info(f"page={page} found={found!r} n={n}")
         if n == 0:
             break
+        data.extend(this_data["results"])
         if n < limit:
             logger.info(f"note: results returned ({n}) < limit ({limit})")
-        data.extend(this_data["results"])
+            break
 
     if isinstance(found, str) and found.startswith(">"):
         print(f"warning: some query results not fetched ('found' is {found!r})")
@@ -532,8 +535,11 @@ def add_data(
         columns={"sensor_ids": "sensor_id", "parameters": "parameter"}
     )
     sensors = sensors.query("parameter == @parameters")
-    sensors = sensors.iloc[:100]  # FIXME: arbitrary limit for testing
-    print(f"using {len(sensors)} sensors from {len(meta)} locations")
+    sensors = sensors.iloc[:1000]  # FIXME: arbitrary limit for testing
+    print(
+        f"requesting data from {len(sensors)} sensors "
+        f"at {sensors.siteid.nunique()} unique locations"
+    )
 
     # TODO: it should be possible to remove sensors not active during the time period
     # TODO: or with sensors input (from a stored list, e.g.) we could bypass location discover/filtering
@@ -566,6 +572,7 @@ def add_data(
             for d in _consume(endpt, params=params, **kwargs)
         ]
 
+    tic = perf_counter()
     if threads is not None:
         import concurrent.futures
         from itertools import chain
@@ -577,6 +584,7 @@ def add_data(
         for tup in iter_queries():
             this_data = tfunc(tup)
             data.extend(this_data)
+    logger.info(f"took {pd.Timedelta(seconds=(perf_counter() - tic))} s to fetch data")
 
     df = pd.DataFrame(data)
     if df.empty:

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -619,9 +619,6 @@ def add_data(
 
     def iter_time_slices():
         # Seems that (from <= time < to) == [from , to) is used
-        # TODO: For consistency with other MONETIO readers,
-        # we want the upper bound in dates to be included in the result.
-        # one_sec = pd.Timedelta(seconds=1)
         if query_dt is not None:
             t = date_min
             while t < date_max:

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -185,6 +185,8 @@ def get_locations(**kwargs):
     https://api.openaq.org/docs#/v3/locations_get_v3_locations_get
     """
 
+    # TODO: multi-thread and/or cache to disk
+
     data = _consume(_ENDPOINTS["locations"], **kwargs)
 
     # Some fields with scalar values to take
@@ -238,7 +240,7 @@ def get_locations(**kwargs):
         sensor_ids = []
         for s in d["sensors"]:
             parameters.append(s["parameter"]["name"])
-            sensor_ids.append([str(x) for x in s["id"]])
+            sensor_ids.append(str(s["id"]))
 
         # Start by taking selected scalars
         d2 = {k: d[k] for k in some_scalars}
@@ -327,7 +329,7 @@ def add_data(
     sites=None,
     entity=None,
     sensor_type=None,
-    query_time_split="1H",
+    query_time_split="1H",  # TODO: raise or remove this, given the single sensor queries
     wide_fmt=False,  # FIXME: probably want to default to True
     **kwargs,
 ):
@@ -419,46 +421,60 @@ def add_data(
         else:
             yield date_min - one_sec, date_max
 
-    base_params = {}
+    # Discover locations
+    print("getting locations...")
+    meta = get_locations(npages=5)  # FIXME: arbitrary limit for testing
+    print(f"found {len(meta)} locations")
+
+    # Narrow locations based on user input
     if country is not None:
-        base_params.update(country=country)
+        meta = meta.query("country_code == @country")
     if sites is not None:
-        base_params.update(location_id=sites)
+        meta = meta.query("siteid == @sites")
     if entity is not None:
-        base_params.update(entity=entity)
+        raise NotImplementedError  # TODO: not sure what to use for this
     if sensor_type is not None:
-        base_params.update(sensor_type=sensor_type)
+        # FIXME: may not be the best approach
+        meta["sensor_type"] = meta["isMonitor"].map(
+            {
+                True: "reference grade",
+                False: "low-cost sensor",
+            }
+        )
+        meta = meta.query("sensor_type == @sensor_type")
+
+    # Pick sensors that have the desired parameters
+    sensors = meta.explode(["sensor_ids", "parameters"])
+    sensors = sensors.query("parameters == @parameters")
+    print(f"using {len(sensors)} sensors from {len(meta)} locations")
+
+    # TODO: it should be possible to remove sensors not active during the time period
+    # TODO: or with sensors input (from a stored list, e.g.) we could bypass location discover/filtering
 
     def iter_queries():
-        for parameter in parameters:
+        for sensor_id in sensors["sensor_ids"]:
             for t_from, t_to in iter_time_slices():
-                yield {
-                    **base_params,
-                    "parameter": parameter,
-                    "date_from": t_from,
-                    "date_to": t_to,
+                yield f"/v3/sensors/{sensor_id}/measurements", {
+                    "datetime_from": t_from,
+                    "datetime_to": t_to,
                 }
 
     threads = kwargs.pop("threads", None)
+
+    def tfunc(tup):
+        endpt, params = tup
+        return _consume(endpt, params=params, **kwargs)
+
     if threads is not None:
         import concurrent.futures
         from itertools import chain
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor:
-            data = chain.from_iterable(
-                executor.map(
-                    lambda params: _consume(_ENDPOINTS["measurements"], params=params, **kwargs),
-                    iter_queries(),
-                )
-            )
+            data = chain.from_iterable(executor.map(tfunc, iter_queries()))
     else:
         data = []
-        for params in iter_queries():
-            this_data = _consume(
-                _ENDPOINTS["measurements"],
-                params=params,
-                **kwargs,
-            )
+        for tup in iter_queries():
+            this_data = tfunc(tup)
             data.extend(this_data)
 
     df = pd.DataFrame(data)

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -15,12 +15,10 @@ https://api.openaq.org/docs#/v3
 """
 
 import functools
-import json
 import logging
 import os
 import warnings
 
-import numpy as np
 import pandas as pd
 import requests
 
@@ -282,6 +280,9 @@ def get_locations(**kwargs):
     return df
 
 
+# TODO: get_sensors(location)
+
+
 @_api_key_warning
 def get_parameters(**kwargs):
     """Get supported parameter info from OpenAQ v3 API.
@@ -423,7 +424,7 @@ def add_data(
 
     # Discover locations
     print("getting locations...")
-    meta = get_locations(npages=5)  # FIXME: arbitrary limit for testing
+    meta = get_locations(npages=1)  # FIXME: arbitrary limit for testing
     print(f"found {len(meta)} locations")
 
     # Narrow locations based on user input
@@ -448,6 +449,7 @@ def add_data(
         columns={"sensor_ids": "sensor_id", "parameters": "parameter"}
     )
     sensors = sensors.query("parameter == @parameters")
+    sensors = sensors.iloc[:10]  # FIXME: arbitrary limit for testing
     print(f"using {len(sensors)} sensors from {len(meta)} locations")
 
     # TODO: it should be possible to remove sensors not active during the time period
@@ -456,7 +458,7 @@ def add_data(
     def iter_queries():
         for sensor_id in sensors["sensor_id"]:
             for t_from, t_to in iter_time_slices():
-                yield f"/v3/sensors/{sensor_id}/measurements", {
+                yield sensor_id, {
                     "datetime_from": t_from,
                     "datetime_to": t_to,
                 }
@@ -464,8 +466,21 @@ def add_data(
     threads = kwargs.pop("threads", None)
 
     def tfunc(tup):
-        endpt, params = tup
-        return _consume(endpt, params=params, **kwargs)
+        sensor_id, params = tup
+        endpt = f"/v3/sensors/{sensor_id}/measurements"
+        return [
+            {
+                "value": d["value"],
+                "parameter_id": d["parameter"]["id"],
+                "period_label": d["period"]["label"],
+                "time_from_utc": d["period"]["datetimeFrom"]["utc"],
+                "time_from_local": d["period"]["datetimeFrom"]["local"],
+                "time_to_utc": d["period"]["datetimeTo"]["utc"],
+                "time_to_local": d["period"]["datetimeTo"]["local"],
+                "sensor_id": sensor_id,
+            }
+            for d in _consume(endpt, params=params, **kwargs)
+        ]
 
     if threads is not None:
         import concurrent.futures
@@ -484,54 +499,34 @@ def add_data(
         print("warning: no data found")
         return df
 
-    #  #   Column       Non-Null Count  Dtype
-    # ---  ------       --------------  -----
-    #  0   locationId   2000 non-null   int64
-    #  1   location     2000 non-null   object
-    #  2   parameter    2000 non-null   object
-    #  3   value        2000 non-null   float64
-    #  4   date         2000 non-null   object
-    #  5   unit         2000 non-null   object
-    #  6   coordinates  2000 non-null   object
-    #  7   country      2000 non-null   object
-    #  8   city         0 non-null      object  # None
-    #  9   isMobile     2000 non-null   bool
-    #  10  isAnalysis   0 non-null      object  # None
-    #  11  entity       2000 non-null   object
-    #  12  sensorType   2000 non-null   object
+    # Convert times to naive datetime, e.g.
+    # {'utc': '2019-08-01T04:00:00Z', 'local': '2019-08-01T00:00:00-04:00'}}
+    for col in ["time_from", "time_to"]:
+        for tz in ["utc", "local"]:
+            df[f"{col}_{tz}"] = pd.to_datetime(df[f"{col}_{tz}"]).dt.tz_localize(None)
 
-    to_expand = ["date", "coordinates"]
-    new = pd.json_normalize(json.loads(df[to_expand].to_json(orient="records")))
+    utcoffset = df["time_from_local"] - df["time_from_utc"]
 
-    time = pd.to_datetime(new["date.utc"]).dt.tz_localize(None)
-    # utcoffset = pd.to_timedelta(new["date.local"].str.slice(-6, None) + ":00")
-    # time_local = time + utcoffset
-    # ^ Seems some have negative minutes in the tz, so this method complains
-    time_local = pd.to_datetime(new["date.local"].str.slice(0, 19))
-    utcoffset = time_local - time
+    # TODO: get lat/lon from sensors df
 
-    # TODO: null case??
-    lat = new["coordinates.latitude"]
-    lon = new["coordinates.longitude"]
-
-    df = df.drop(columns=to_expand).assign(
-        time=time,
-        time_local=time_local,
+    df = df.assign(
+        time=df["time_from_utc"],  # left-labelled
+        time_local=df["time_from_local"],
         utcoffset=utcoffset,
-        latitude=lat,
-        longitude=lon,
+        # latitude=lat,
+        # longitude=lon,
+    ).drop(
+        columns=[
+            "time_from_utc",
+            "time_from_local",
+            "time_to_utc",
+            "time_to_local",
+        ]
     )
 
-    # Rename columns and ensure site ID is string
-    df = df.rename(
-        columns={
-            "locationId": "siteid",
-            "isMobile": "is_mobile",
-            "isAnalysis": "is_analysis",
-            "sensorType": "sensor_type",
-        },
-    )
-    df["siteid"] = df.siteid.astype(str)
+    # TODO: get site info in from meta df
+
+    # TODO: get units and name in from parameters df
 
     # Most variables invalid if < 0
     # > preferredUnit.value_counts()
@@ -551,24 +546,24 @@ def add_data(
     # f                 1
     # mb                1
     # iaq               1
-    non_neg_units = [
-        "particles/cm³",
-        "ppm",
-        "ppb",
-        "umol/mol",
-        "µg/m³",
-        "ugm3",
-        "ng/m3",
-        "iaq",
-        #
-        "%",
-        #
-        "m/s",
-        #
-        "hpa",
-        "mb",
-    ]
-    df.loc[df.unit.isin(non_neg_units) & (df.value < 0), "value"] = np.nan
+    # non_neg_units = [
+    #     "particles/cm³",
+    #     "ppm",
+    #     "ppb",
+    #     "umol/mol",
+    #     "µg/m³",
+    #     "ugm3",
+    #     "ng/m3",
+    #     "iaq",
+    #     #
+    #     "%",
+    #     #
+    #     "m/s",
+    #     #
+    #     "hpa",
+    #     "mb",
+    # ]
+    # df.loc[df.unit.isin(non_neg_units) & (df.value < 0), "value"] = np.nan
 
     if wide_fmt:
         # Normalize units

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -1,4 +1,4 @@
-"""Get AQ data from the OpenAQ v2 REST API.
+"""Get AQ data from the OpenAQ v3 REST API.
 
 Visit https://docs.openaq.org/docs/getting-started to get an API key
 and set environment variable ``OPENAQ_API_KEY`` to use it.
@@ -11,7 +11,7 @@ For example, in Bash:
 
 https://openaq.org/
 
-https://api.openaq.org/docs#/v2
+https://api.openaq.org/docs#/v3
 """
 
 import functools
@@ -69,7 +69,7 @@ def _api_key_warning(func):
     def wrapper(*args, **kwargs):
         if API_KEY is None:
             warnings.warn(
-                "Non-cached requests to the OpenAQ v2 web API will be slow without an API key "
+                "Non-cached requests to the OpenAQ v3 web API will be slow without an API key "
                 "or requests will fail (HTTP error 401). "
                 "Obtain one (https://docs.openaq.org/docs/getting-started#api-key) "
                 "and set your OPENAQ_API_KEY environment variable.",
@@ -82,9 +82,9 @@ def _api_key_warning(func):
 
 _BASE_URL = "https://api.openaq.org"
 _ENDPOINTS = {
-    "locations": "/v2/locations",
-    "parameters": "/v2/parameters",
-    "measurements": "/v2/measurements",
+    "locations": "/v3/locations",
+    "parameters": "/v3/parameters",
+    "sensors": "/v3/sensors",
 }
 
 
@@ -94,7 +94,8 @@ def _consume(endpoint, *, params=None, timeout=10, retry=5, limit=500, npages=No
     Parameters
     ----------
     endpoint : str
-        API endpoint, e.g. ``'/v2/locations'``, ``'/v2/parameters'``, ``'/v2/measurements'``.
+        API endpoint, e.g. ``'/v3/locations'``, ``'/v3/parameters'``, ``'/v3/sensors'``,
+        ``'/v3/sensors/<sensor id>/measurements'``.
     params : dict, optional
         Parameters for the GET request to the API.
         Don't pass ``limit``, ``page``, or ``offset`` here, since they are covered
@@ -114,8 +115,8 @@ def _consume(endpoint, *, params=None, timeout=10, retry=5, limit=500, npages=No
 
     if not endpoint.startswith("/"):
         endpoint = "/" + endpoint
-    if not endpoint.startswith("/v2"):
-        endpoint = "/v2" + endpoint
+    if not endpoint.startswith("/v3"):
+        endpoint = "/v3" + endpoint
     url = _BASE_URL + endpoint
 
     if params is None:
@@ -177,11 +178,11 @@ def _consume(endpoint, *, params=None, timeout=10, retry=5, limit=500, npages=No
 
 @_api_key_warning
 def get_locations(**kwargs):
-    """Get available site info (including site IDs) from OpenAQ v2 API.
+    """Get available site info (including site IDs) from OpenAQ v3 API.
 
     kwargs are passed to :func:`_consume`.
 
-    https://api.openaq.org/docs#/v2/locations_get_v2_locations_get
+    https://api.openaq.org/docs#/v3/locations_get_v3_locations_get
     """
 
     data = _consume(_ENDPOINTS["locations"], **kwargs)
@@ -242,8 +243,9 @@ def get_locations(**kwargs):
     return df
 
 
+@_api_key_warning
 def get_parameters(**kwargs):
-    """Get supported parameter info from OpenAQ v2 API.
+    """Get supported parameter info from OpenAQ v3 API.
 
     kwargs are passed to :func:`_consume`.
     """
@@ -293,7 +295,7 @@ def add_data(
     wide_fmt=False,  # FIXME: probably want to default to True
     **kwargs,
 ):
-    """Get OpenAQ API v2 data, including low-cost sensors.
+    """Get OpenAQ API v3 data, including low-cost sensors.
 
     Parameters
     ----------

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -612,7 +612,7 @@ def add_data(
                 "must provide at least two unique datetimes to use query_time_split. "
                 "Set query_time_split=None to disable time splitting."
             )
-        if hourly:
+        if hourly or raw:
             date_max = date_max + pd.Timedelta(hours=1)
         elif daily:
             date_max = date_max + pd.Timedelta(days=1)
@@ -737,7 +737,15 @@ def add_data(
         ]
     )
 
-    if daily:
+    if raw:
+        df = df[
+            df.time.between(
+                date_min.tz_localize(None),
+                date_max.tz_localize(None) - pd.Timedelta(hours=1),
+                inclusive="both",
+            )
+        ]
+    elif daily:
         # We only need the date
         assert df["time_local"].eq(df["time_local"].dt.floor("D")).all()
         df = df.assign(time=df["time_local"]).drop(columns=["time_local"])

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -155,7 +155,7 @@ def _consume(endpoint, *, params=None, timeout=10, retry=5, limit=500, npages=No
                 time.sleep(tries + 0.1 * rand())
             elif r.status_code == 429:
                 logger.info(f"rate limited (try {tries}/{retry})")
-                ratelimit_reset = int(r.headers.get("X-Ratelimit-Reset", 60))
+                ratelimit_reset = int(r.headers.get("X-Ratelimit-Reset", 30))
                 logger.info(f"sleeping for {ratelimit_reset} s (rate limit reset)")
                 time.sleep(ratelimit_reset + 0.1 * rand())
             else:

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -340,7 +340,7 @@ def get_sensors(location_id, **kwargs):
             last_time = last_time.get("utc", None)
 
         d2 = {
-            "id": d["id"],
+            "id": str(d["id"]),
             "name": d["name"],
             "parameter": d["parameter"]["name"],
             "parameter_id": d["parameter"]["id"],
@@ -408,6 +408,7 @@ def add_data(
     sites=None,
     entity=None,
     sensor_type=None,
+    sensor_ids=None,
     query_time_split="1H",  # TODO: raise or remove this, given the single sensor queries
     wide_fmt=False,  # FIXME: probably want to default to True
     **kwargs,
@@ -428,6 +429,9 @@ def add_data(
     sites : list of str, optional
         Site ID(s) to include, e.g. a specific known site
         or group of sites from :func:`get_latlonbox_sites`.
+        Note that in the OpenAQ API, these are called 'location IDs'
+        and are integers, not strings.
+        We use strings here for consistency with other MONETIO obs readers.
         Default: full dataset (no limitation by site).
     entity : str or list of str, optional
         Options: ``'government'``, ``'research'``, ``'community'``.
@@ -435,6 +439,9 @@ def add_data(
     sensor_type : str or list of str, optional
         Options: ``'low-cost sensor'``, ``'reference grade'``.
         Default: full dataset (no limitation by sensor type).
+    sensor_ids : str or list of str, optional
+        Sensor ID(s) to include.
+        Default: full dataset (no limitation by sensor).
     query_time_split
         Frequency to use when splitting the web API queries in time,
         in a format that ``pandas.to_timedelta`` will understand.
@@ -535,7 +542,11 @@ def add_data(
         columns={"sensor_ids": "sensor_id", "parameters": "parameter"}
     )
     sensors = sensors.query("parameter == @parameters")
-    sensors = sensors.iloc[:1000]  # FIXME: arbitrary limit for testing
+    sensor_limit = kwargs.pop("sensor_limit", None)  # for testing
+    if sensor_limit is not None:
+        sensors = sensors.iloc[:sensor_limit]
+    if sensor_ids is not None:
+        sensors = sensors.query("sensor_id == @sensor_ids")
     print(
         f"requesting data from {len(sensors)} sensors "
         f"at {sensors.siteid.nunique()} unique locations"

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -447,6 +447,8 @@ def _to_wide_fmt(df):
         "is_monitor",
         "period_label",
     ]
+    if "time_local" not in df.columns:  # daily data
+        index.remove("time_local")
     assert sorted(index + ["parameter", "value", "units"]) == sorted(df.columns)
 
     dupes = df[df.duplicated(keep=False)]
@@ -560,8 +562,6 @@ def add_data(
     dates = dates.dropna()
     if dates.empty:
         raise ValueError("must provide at least one datetime-like")
-    if dates.tz is None:
-        dates = dates.tz_localize("UTC")
 
     if parameters is None:
         parameters = ["pm25", "o3"]
@@ -589,6 +589,16 @@ def add_data(
         endpt_tpl += "/hourly"
     elif daily:
         endpt_tpl += "/daily"
+
+    # The API seems to assume local time if tz is not set.
+    # Usually we _do_ want/mean UTC, but for daily, we want to select dates,
+    # which are local time, and we don't want worry about tz differences
+    # for different sites.
+    if dates.tz is None and not daily:
+        dates = dates.tz_localize("UTC")
+    if daily and dates.tz is not None:
+        warnings.warn("ignoring tz for daily data")
+        dates = dates.tz_localize(None)
 
     query_dt = pd.to_timedelta(query_time_split) if len(dates) > 1 else None
     date_min, date_max = dates.min(), dates.max()
@@ -665,7 +675,6 @@ def add_data(
     def iter_queries():
         for sensor_id in sensors["sensor_id"]:
             for t_from, t_to in iter_time_slices():
-                # TODO: should these be UTC or local here? and does naive vs non-naive make a difference?
                 yield sensor_id, {
                     "datetime_from": t_from,
                     "datetime_to": t_to,
@@ -730,6 +739,11 @@ def add_data(
             "time_to_local",
         ]
     )
+
+    if daily:
+        # We only need the date
+        assert df["time_local"].eq(df["time_local"].dt.floor("D")).all()
+        df = df.assign(time=df["time_local"]).drop(columns=["time_local"])
 
     # Get site info in from meta df
     df = df.merge(
@@ -818,6 +832,8 @@ def add_data(
         "is_monitor",
         "period_label",
     ]
+    if daily:
+        col_order.remove("time_local")
     assert sorted(df.columns) == sorted(col_order)
     df = df[col_order]
 

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -578,12 +578,12 @@ def add_data(
     def iter_time_slices():
         # seems that (from < time <= to) == (from , to] is used
         # i.e. `from` is exclusive, `to` is inclusive
-        one_sec = pd.Timedelta(seconds=1)
+        # one_sec = pd.Timedelta(seconds=1)
         if query_dt is not None:
             t = date_min
             while t < date_max:
                 t_next = min(t + query_dt, date_max)
-                yield t - one_sec, t_next
+                yield t, t_next
                 t = t_next
         else:
             # yield date_min - one_sec, date_max

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -612,10 +612,10 @@ def add_data(
                 "must provide at least two unique datetimes to use query_time_split. "
                 "Set query_time_split=None to disable time splitting."
             )
-        if hourly or raw:
-            date_max = date_max + pd.Timedelta(hours=1)
-        elif daily:
-            date_max = date_max + pd.Timedelta(days=1)
+    if hourly or raw:
+        date_max = date_max + pd.Timedelta(hours=1)
+    elif daily:
+        date_max = date_max + pd.Timedelta(days=1)
 
     def iter_time_slices():
         # Seems that (from <= time < to) == [from , to) is used

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -478,6 +478,9 @@ def add_data(
     dates,
     *,
     parameters=None,
+    raw=None,
+    hourly=None,
+    daily=None,
     country=None,
     sites=None,
     entity=None,
@@ -497,6 +500,9 @@ def add_data(
         as inclusive time bounds of the desired data.
     parameters : str or list of str, optional
         For example, ``'o3'`` or ``['pm25', 'o3']`` (default).
+    raw, hourly, daily : bool, optional
+        Select product (use only one of these).
+        By default, raw data is returned.
     country : str or list of str, optional
         For example, ``'US'`` or ``['US', 'CA']`` (two-letter country codes).
         Default: full dataset (no limitation by country).
@@ -562,6 +568,28 @@ def add_data(
     elif isinstance(parameters, str):
         parameters = [parameters]
 
+    if all([raw is None, hourly is None, daily is None]):
+        # Default to raw
+        # FIXME: probably want hourly to be the default
+        raw = True
+        hourly = False
+        daily = False
+    else:
+        # User specified one (or more)
+        if raw is None:
+            raw = False
+        if hourly is None:
+            hourly = False
+        if daily is None:
+            daily = False
+    if sum([raw, hourly, daily]) != 1:
+        raise ValueError("exactly one of raw, hourly, daily can be True")
+    endpt_tpl = "/v3/sensors/{sensor_id}/measurements"
+    if hourly:
+        endpt_tpl += "/hourly"
+    elif daily:
+        endpt_tpl += "/daily"
+
     query_dt = pd.to_timedelta(query_time_split) if len(dates) > 1 else None
     date_min, date_max = dates.min(), dates.max()
     if query_dt is not None:
@@ -574,10 +602,15 @@ def add_data(
                 "must provide at least two unique datetimes to use query_time_split. "
                 "Set query_time_split=None to disable time splitting."
             )
+        if hourly:
+            date_max = date_max + pd.Timedelta(hours=1)
+        elif daily:
+            date_max = date_max + pd.Timedelta(days=1)
 
     def iter_time_slices():
-        # seems that (from < time <= to) == (from , to] is used
-        # i.e. `from` is exclusive, `to` is inclusive
+        # Seems that (from <= time < to) == [from , to) is used
+        # TODO: For consistency with other MONETIO readers,
+        # we want the upper bound in dates to be included in the result.
         # one_sec = pd.Timedelta(seconds=1)
         if query_dt is not None:
             t = date_min
@@ -586,9 +619,7 @@ def add_data(
                 yield t, t_next
                 t = t_next
         else:
-            # yield date_min - one_sec, date_max
             yield date_min, date_max
-            # TODO: minus one sec seems no longer necessary
 
     # Discover locations
     print("getting locations...")
@@ -627,8 +658,8 @@ def add_data(
     if sensor_ids is not None:
         sensors = sensors.query("sensor_id == @sensor_ids")
     print(
-        f"requesting data from {len(sensors)} sensors "
-        f"at {sensors.siteid.nunique()} unique locations"
+        f"requesting data from {len(sensors)} sensor(s) "
+        f"at {sensors.siteid.nunique()} unique location(s)"
     )
 
     def iter_queries():
@@ -644,7 +675,7 @@ def add_data(
 
     def tfunc(tup):
         sensor_id, params = tup
-        endpt = f"/v3/sensors/{sensor_id}/measurements"
+        endpt = endpt_tpl.format(sensor_id=sensor_id)
         return [
             {
                 "value": d["value"],

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -444,15 +444,17 @@ def add_data(
         meta = meta.query("sensor_type == @sensor_type")
 
     # Pick sensors that have the desired parameters
-    sensors = meta.explode(["sensor_ids", "parameters"])
-    sensors = sensors.query("parameters == @parameters")
+    sensors = meta.explode(["sensor_ids", "parameters"], ignore_index=True).rename(
+        columns={"sensor_ids": "sensor_id", "parameters": "parameter"}
+    )
+    sensors = sensors.query("parameter == @parameters")
     print(f"using {len(sensors)} sensors from {len(meta)} locations")
 
     # TODO: it should be possible to remove sensors not active during the time period
     # TODO: or with sensors input (from a stored list, e.g.) we could bypass location discover/filtering
 
     def iter_queries():
-        for sensor_id in sensors["sensor_ids"]:
+        for sensor_id in sensors["sensor_id"]:
             for t_from, t_to in iter_time_slices():
                 yield f"/v3/sensors/{sensor_id}/measurements", {
                     "datetime_from": t_from,

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -19,6 +19,7 @@ import logging
 import os
 import warnings
 
+import numpy as np
 import pandas as pd
 import requests
 
@@ -193,7 +194,7 @@ def get_locations(**kwargs):
         "name",
         "locality",
         "timezone",
-        "isMobile",
+        "isMobile",  # TODO: rename these two to snake_case
         "isMonitor",
         "distance",
     ]
@@ -507,14 +508,11 @@ def add_data(
 
     utcoffset = df["time_from_local"] - df["time_from_utc"]
 
-    # TODO: get lat/lon from sensors df
-
+    # Choose time
     df = df.assign(
         time=df["time_from_utc"],  # left-labelled
         time_local=df["time_from_local"],
         utcoffset=utcoffset,
-        # latitude=lat,
-        # longitude=lon,
     ).drop(
         columns=[
             "time_from_utc",
@@ -524,9 +522,39 @@ def add_data(
         ]
     )
 
-    # TODO: get site info in from meta df
+    # Get site info in from meta df
+    df = df.merge(
+        sensors[
+            [
+                "country_code",
+                "siteid",
+                "latitude",
+                "longitude",
+                "sensor_id",
+                "isMobile",
+                "isMonitor",
+            ]
+        ],
+        on="sensor_id",
+        how="left",
+    ).rename(
+        columns={
+            "country_code": "country",
+        }
+    )
 
-    # TODO: get units and name in from parameters df
+    # Add parameter info
+    parameters = get_parameters().rename(
+        columns={
+            "id": "parameter_id",
+            "name": "parameter",
+        }
+    )
+    df = df.merge(
+        parameters[["parameter_id", "parameter", "units"]],
+        on="parameter_id",
+        how="left",
+    ).drop(columns="parameter_id")
 
     # Most variables invalid if < 0
     # > preferredUnit.value_counts()
@@ -546,34 +574,53 @@ def add_data(
     # f                 1
     # mb                1
     # iaq               1
-    # non_neg_units = [
-    #     "particles/cm³",
-    #     "ppm",
-    #     "ppb",
-    #     "umol/mol",
-    #     "µg/m³",
-    #     "ugm3",
-    #     "ng/m3",
-    #     "iaq",
-    #     #
-    #     "%",
-    #     #
-    #     "m/s",
-    #     #
-    #     "hpa",
-    #     "mb",
-    # ]
-    # df.loc[df.unit.isin(non_neg_units) & (df.value < 0), "value"] = np.nan
+    non_neg_units = [
+        "particles/cm³",
+        "ppm",
+        "ppb",
+        "umol/mol",
+        "µg/m³",
+        "ugm3",
+        "ng/m3",
+        "iaq",
+        #
+        "%",
+        #
+        "m/s",
+        #
+        "hpa",
+        "mb",
+    ]
+    df.loc[df.units.isin(non_neg_units) & (df.value < 0), "value"] = np.nan
+
+    col_order = [
+        "parameter",
+        "value",
+        "units",
+        "time",
+        "siteid",
+        "latitude",
+        "longitude",
+        "time_local",
+        "utcoffset",
+        "country",
+        "sensor_id",
+        "isMobile",
+        "isMonitor",
+        "period_label",
+    ]
+    assert sorted(df.columns) == sorted(col_order)
+    df = df[col_order]
 
     if wide_fmt:
         # Normalize units
         for vn, f in _PPM_TO_UGM3.items():
-            is_ug = (df.parameter == vn) & (df.unit == "µg/m³")
+            is_ug = (df.parameter == vn) & (df.units == "µg/m³")
             df.loc[is_ug, "value"] /= f
             df.loc[is_ug, "unit"] = "ppm"
 
         # Warn if inconsistent units
-        p_units = df.groupby("parameter").unit.unique()
+        p_units = df.groupby("parameter").units.unique()
         unique = p_units.apply(len).eq(1)
         if not unique.all():
             p_units_non_unique = p_units[~unique]

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -112,6 +112,10 @@ def _consume(endpoint, *, params=None, timeout=10, retry=5, limit=500, npages=No
     npages : int, optional
         Number of pages to fetch.
         By default, try to fetch as many as needed to get all results.
+
+    Notes
+    -----
+    Rate limit info: https://docs.openaq.org/using-the-api/rate-limits
     """
     import time
     from random import random as rand

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -415,7 +415,8 @@ def _to_wide_fmt(df):
 
     # Certain metadata should be unique for a given site but sometimes aren't
     # (e.g. location names of different specificity, slight differences in lat/lon coords)
-    for col in ["latitude", "longitude"]:  # TODO: location name too
+    # TODO: would be nice to have location name too
+    for col in ["latitude", "longitude"]:
         site_col = df.groupby("siteid")[col].unique()
         unique = site_col.apply(len).eq(1)
         if not unique.all():
@@ -629,9 +630,6 @@ def add_data(
         f"requesting data from {len(sensors)} sensors "
         f"at {sensors.siteid.nunique()} unique locations"
     )
-
-    # TODO: it should be possible to remove sensors not active during the time period
-    # TODO: or with sensors input (from a stored list, e.g.) we could bypass location discover/filtering
 
     def iter_queries():
         for sensor_id in sensors["sensor_id"]:

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -198,24 +198,28 @@ def get_locations(**kwargs):
     kwargs["limit"] = kwargs.get("limit", 1000)
 
     p = HERE / "openaq_locations_data.json.gz"
-    have_cache = False
-    if p.is_file():
-        now = pd.Timestamp.now(tz="UTC")
-        mtime = pd.Timestamp.fromtimestamp(p.stat().st_mtime, tz="UTC")
-        logger.info(f"locations cache file exists, mtime {mtime:%Y-%m-%d %H:%M:%SZ}")
-        if now - mtime < pd.Timedelta(days=7):
-            have_cache = True
-        else:
-            logger.info("locations cache file is old, will refresh")
-    else:
-        logger.info("locations cache file not found, will create")
 
-    if not have_cache:
-        with FileLock(p.as_posix() + ".lock"):
+    def have_cache():
+        if p.is_file():
+            now = pd.Timestamp.now(tz="UTC")
+            mtime = pd.Timestamp.fromtimestamp(p.stat().st_mtime, tz="UTC")
+            logger.info(f"locations cache file exists, mtime {mtime:%Y-%m-%d %H:%M:%SZ}")
+            if now - mtime < pd.Timedelta(days=7):
+                return True
+            else:
+                logger.info("locations cache file is old, will refresh")
+        else:
+            logger.info("locations cache file not found, will create")
+        return False
+
+    data = None
+    with FileLock(p.as_posix() + ".lock"):
+        if not have_cache():
             data = _consume(_ENDPOINTS["locations"], **kwargs)
             with gzip.open(p, "wt") as f:
                 json.dump(data, f)
-    else:
+
+    if data is None:
         logger.info("using cached locations data")
         with gzip.open(p, "rt") as f:
             data = json.load(f)

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -190,33 +190,34 @@ def get_locations(**kwargs):
     https://api.openaq.org/docs#/v3/locations_get_v3_locations_get
     """
 
+    import gzip
     import json
 
     from filelock import FileLock
 
     kwargs["limit"] = kwargs.get("limit", 1000)
 
-    # TODO: gzip? or place in user cache dir instead?
-    p = HERE / "openaq_locations_data.json"
+    p = HERE / "openaq_locations_data.json.gz"
     have_cache = False
     if p.is_file():
         now = pd.Timestamp.now(tz="UTC")
         mtime = pd.Timestamp.fromtimestamp(p.stat().st_mtime, tz="UTC")
+        logger.info(f"locations cache file exists, mtime {mtime:%Y-%m-%d %H:%M:%SZ}")
         if now - mtime < pd.Timedelta(days=7):
             have_cache = True
         else:
-            logger.info(f"locations cache file is old ({mtime:%Y-%m-%d %H:%M:%SZ}), will refresh")
+            logger.info("locations cache file is old, will refresh")
     else:
-        logger.info("no locations cache file")
+        logger.info("locations cache file not found, will create")
 
     if not have_cache:
         with FileLock(p.as_posix() + ".lock"):
             data = _consume(_ENDPOINTS["locations"], **kwargs)
-            with open(p, "w") as f:
+            with gzip.open(p, "wt") as f:
                 json.dump(data, f)
     else:
         logger.info("using cached locations data")
-        with open(p) as f:
+        with gzip.open(p, "rt") as f:
             data = json.load(f)
 
     # Some fields with scalar values to take

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -236,9 +236,11 @@ def get_locations(**kwargs):
         lat = d["coordinates"]["latitude"]
         lon = d["coordinates"]["longitude"]
         parameters = []
+        parameter_ids = []
         sensor_ids = []
         for s in d["sensors"]:
             parameters.append(s["parameter"]["name"])
+            parameter_ids.append(s["parameter"]["id"])
             sensor_ids.append(str(s["id"]))
 
         # Start by taking selected scalars
@@ -255,6 +257,7 @@ def get_locations(**kwargs):
             latitude=lat,
             longitude=lon,
             parameters=parameters,
+            parameter_ids=parameters,
             sensor_ids=sensor_ids,
         )
 
@@ -286,7 +289,45 @@ def get_locations(**kwargs):
     return df
 
 
-# TODO: get_sensors(location)
+@_api_key_warning
+def get_sensors(location_id, **kwargs):
+    """Get sensors for a location (ID; aka 'siteid')."""
+
+    # Doesn't seem to be paging properly?
+    # (Next page always has the same n)
+    # So set to one page for now
+    kwargs["limit"] = kwargs.get("limit", 1000)
+    kwargs["npages"] = kwargs.get("npages", 1)
+
+    data2 = []
+    for d in _consume(f"/v3/locations/{location_id}/sensors", **kwargs):
+        first_time = d["datetimeFirst"]
+        if first_time is not None:
+            first_time = first_time.get("utc", None)
+        last_time = d["datetimeLast"]
+        if last_time is not None:
+            last_time = last_time.get("utc", None)
+
+        d2 = {
+            "id": d["id"],
+            "name": d["name"],
+            "parameter": d["parameter"]["name"],
+            "parameter_id": d["parameter"]["id"],
+            "first_time": first_time,
+            "last_time": last_time,
+        }
+
+        data2.append(d2)
+
+    df = pd.DataFrame(data2)
+
+    # Compute datetimes
+    for col in ["first_time", "last_time"]:
+        i = df[col].notnull()
+        assert df.loc[i, col].str.slice(-1, None).eq("Z").all()
+        df[col] = pd.to_datetime(df[col].str.slice(0, -1))
+
+    return df
 
 
 @_api_key_warning

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -194,7 +194,7 @@ def get_locations(**kwargs):
         "name",
         "locality",
         "timezone",
-        "isMobile",  # TODO: rename these two to snake_case
+        "isMobile",
         "isMonitor",
         "distance",
     ]
@@ -260,7 +260,12 @@ def get_locations(**kwargs):
 
         data2.append(d2)
 
-    df = pd.DataFrame(data2)
+    df = pd.DataFrame(data2).rename(
+        columns={
+            "isMobile": "is_mobile",
+            "isMonitor": "is_monitor",
+        }
+    )
 
     # Compute datetimes
     for col in ["first_time", "last_time"]:
@@ -293,7 +298,7 @@ def get_parameters(**kwargs):
 
     data = _consume(_ENDPOINTS["parameters"], **kwargs)
 
-    df = pd.DataFrame(data)
+    df = pd.DataFrame(data).rename(columns={"displayName": "display_name"})
 
     return df
 
@@ -437,7 +442,7 @@ def add_data(
         raise NotImplementedError  # TODO: not sure what to use for this
     if sensor_type is not None:
         # FIXME: may not be the best approach
-        meta["sensor_type"] = meta["isMonitor"].map(
+        meta["sensor_type"] = meta["is_monitor"].map(
             {
                 True: "reference grade",
                 False: "low-cost sensor",
@@ -531,8 +536,8 @@ def add_data(
                 "latitude",
                 "longitude",
                 "sensor_id",
-                "isMobile",
-                "isMonitor",
+                "is_mobile",
+                "is_monitor",
             ]
         ],
         on="sensor_id",
@@ -605,8 +610,8 @@ def add_data(
         "utcoffset",
         "country",
         "sensor_id",
-        "isMobile",
-        "isMonitor",
+        "is_mobile",
+        "is_monitor",
         "period_label",
     ]
     assert sorted(df.columns) == sorted(col_order)

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -482,7 +482,7 @@ def add_data(
     entity=None,
     sensor_type=None,
     sensor_ids=None,
-    query_time_split="1H",  # TODO: raise or remove this, given the single sensor queries
+    query_time_split=None,
     wide_fmt=False,  # FIXME: probably want to default to True
     **kwargs,
 ):
@@ -518,12 +518,17 @@ def add_data(
     query_time_split
         Frequency to use when splitting the web API queries in time,
         in a format that ``pandas.to_timedelta`` will understand.
-        This is necessary since there is a 100k limit on the number of results.
-        However, in some cases you may want to set this
-        to something higher in order to increase the query return speed.
-        Set to ``None`` for no time splitting.
-        Default: 1 hour
-        (OpenAQ data are hourly, so setting to something smaller won't help).
+        There is a 100k limit on the number of results you can get from a single query.
+        In this version of the OpenAQ web API, each sensor has its own endpoint
+        and so is a separate query,
+        but 100k equates to more than 10 years of hourly data.
+        For many use cases, data from a single sensor fits in one page
+        (the default page size, controlled by `limit`, is 500).
+        Time splitting might still be useful if you are requesting
+        a long record from a single sensor, for example,
+        to allow for multi-threaded requesting.
+        Set to ``None`` for no time splitting (default).
+        Default: no time splitting
         Ignored if only one date/time is provided.
     wide_fmt : bool
         Convert dataframe to wide format (one column per parameter).

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -634,9 +634,9 @@ def add_data(
             yield date_min, date_max
 
     # Discover locations
-    print("getting locations...")
+    print("loading locations...")
     meta = get_locations()
-    print(f"found {len(meta)} locations")
+    print(f"{len(meta)} locations detected")
 
     # Narrow locations based on user input
     if country is not None:

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -234,7 +234,11 @@ def get_locations(**kwargs):
             last_time = last_time.get("utc", None)
         lat = d["coordinates"]["latitude"]
         lon = d["coordinates"]["longitude"]
-        parameters = [s["parameter"]["name"] for s in d["sensors"]]
+        parameters = []
+        sensor_ids = []
+        for s in d["sensors"]:
+            parameters.append(s["parameter"]["name"])
+            sensor_ids.append(s["id"])
 
         # Start by taking selected scalars
         d2 = {k: d[k] for k in some_scalars}
@@ -250,6 +254,7 @@ def get_locations(**kwargs):
             latitude=lat,
             longitude=lon,
             parameters=parameters,
+            sensor_ids=sensor_ids,
         )
 
         data2.append(d2)

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -713,10 +713,23 @@ def add_data(
     tic = perf_counter()
     if threads is not None:
         import concurrent.futures
-        from itertools import chain
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor:
-            data = chain.from_iterable(executor.map(tfunc, iter_queries()))
+            futures = [executor.submit(tfunc, tup) for tup in iter_queries()]
+            data = []
+            done, not_done = concurrent.futures.wait(
+                futures,
+                return_when="FIRST_EXCEPTION",
+            )
+            logger.info(f"{len(done)} tasks done, {len(not_done)} not done")
+            for future in done:
+                e = future.exception()
+                if e is not None:
+                    logger.error(f"thread raised {e!r}")
+                    for future in not_done:
+                        future.cancel()
+                    raise RuntimeError("exception raised in thread") from e
+                data.extend(future.result())
     else:
         data = []
         for tup in iter_queries():

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -1,6 +1,6 @@
 """Get AQ data from the OpenAQ v3 REST API.
 
-Visit https://docs.openaq.org/docs/getting-started to get an API key
+Visit https://docs.openaq.org/using-the-api/api-key to get an API key
 and set environment variable ``OPENAQ_API_KEY`` to use it.
 
 For example, in Bash:
@@ -74,7 +74,7 @@ def _api_key_warning(func):
             warnings.warn(
                 "Non-cached requests to the OpenAQ v3 web API will be slow without an API key "
                 "or requests will fail (HTTP error 401). "
-                "Obtain one (https://docs.openaq.org/docs/getting-started#api-key) "
+                "Obtain one (https://docs.openaq.org/using-the-api/api-key) "
                 "and set your OPENAQ_API_KEY environment variable.",
                 stacklevel=2,
             )

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -324,7 +324,6 @@ def add_data(
     *,
     parameters=None,
     country=None,
-    search_radius=None,
     sites=None,
     entity=None,
     sensor_type=None,
@@ -345,10 +344,6 @@ def add_data(
     country : str or list of str, optional
         For example, ``'US'`` or ``['US', 'CA']`` (two-letter country codes).
         Default: full dataset (no limitation by country).
-    search_radius : dict, optional
-        Mapping of coords tuple (lat, lon) [deg] to search radius [m] (max of 25 km).
-        For example: ``search_radius={(39.0, -77.0): 10_000}``.
-        Note that this dict can contain multiple entries.
     sites : list of str, optional
         Site ID(s) to include, e.g. a specific known site
         or group of sites from :func:`get_latlonbox_sites`.
@@ -363,7 +358,7 @@ def add_data(
         Frequency to use when splitting the web API queries in time,
         in a format that ``pandas.to_timedelta`` will understand.
         This is necessary since there is a 100k limit on the number of results.
-        However, if you are using search radii, e.g., you may want to set this
+        However, in some cases you may want to set this
         to something higher in order to increase the query return speed.
         Set to ``None`` for no time splitting.
         Default: 1 hour
@@ -411,14 +406,6 @@ def add_data(
                 "Set query_time_split=None to disable time splitting."
             )
 
-    if search_radius is not None:
-        for coords, radius in search_radius.items():
-            if not 0 < radius <= 25_000:
-                raise ValueError(
-                    f"invalid radius {radius!r} for location {coords!r}. "
-                    "Must be positive and <= 25000 (25 km)."
-                )
-
     def iter_time_slices():
         # seems that (from < time <= to) == (from , to] is used
         # i.e. `from` is exclusive, `to` is inclusive
@@ -445,24 +432,12 @@ def add_data(
     def iter_queries():
         for parameter in parameters:
             for t_from, t_to in iter_time_slices():
-                if search_radius is not None:
-                    for coords, radius in search_radius.items():
-                        lat, lon = coords
-                        yield {
-                            **base_params,
-                            "parameter": parameter,
-                            "date_from": t_from,
-                            "date_to": t_to,
-                            "coordinates": f"{lat:.8f},{lon:.8f}",
-                            "radius": radius,
-                        }
-                else:
-                    yield {
-                        **base_params,
-                        "parameter": parameter,
-                        "date_from": t_from,
-                        "date_to": t_to,
-                    }
+                yield {
+                    **base_params,
+                    "parameter": parameter,
+                    "date_from": t_from,
+                    "date_to": t_to,
+                }
 
     threads = kwargs.pop("threads", None)
     if threads is not None:

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -437,6 +437,8 @@ def add_data(
     dates = dates.dropna()
     if dates.empty:
         raise ValueError("must provide at least one datetime-like")
+    if dates.tz is None:
+        dates = dates.tz_localize("UTC")
 
     if parameters is None:
         parameters = ["pm25", "o3"]
@@ -467,11 +469,13 @@ def add_data(
                 yield t - one_sec, t_next
                 t = t_next
         else:
-            yield date_min - one_sec, date_max
+            # yield date_min - one_sec, date_max
+            yield date_min, date_max
+            # TODO: minus one sec seems no longer necessary
 
     # Discover locations
     print("getting locations...")
-    meta = get_locations(npages=1)  # FIXME: arbitrary limit for testing
+    meta = get_locations(npages=10)  # FIXME: arbitrary limit for testing
     print(f"found {len(meta)} locations")
 
     # Narrow locations based on user input
@@ -490,13 +494,17 @@ def add_data(
             }
         )
         meta = meta.query("sensor_type == @sensor_type")
+    meta = meta[
+        (meta.first_time <= date_max.tz_localize(None))
+        & (meta.last_time >= date_min.tz_localize(None))
+    ]
 
     # Pick sensors that have the desired parameters
     sensors = meta.explode(["sensor_ids", "parameters"], ignore_index=True).rename(
         columns={"sensor_ids": "sensor_id", "parameters": "parameter"}
     )
     sensors = sensors.query("parameter == @parameters")
-    sensors = sensors.iloc[:10]  # FIXME: arbitrary limit for testing
+    sensors = sensors.iloc[:100]  # FIXME: arbitrary limit for testing
     print(f"using {len(sensors)} sensors from {len(meta)} locations")
 
     # TODO: it should be possible to remove sensors not active during the time period
@@ -505,6 +513,7 @@ def add_data(
     def iter_queries():
         for sensor_id in sensors["sensor_id"]:
             for t_from, t_to in iter_time_slices():
+                # TODO: should these be UTC or local here? and does naive vs non-naive make a difference?
                 yield sensor_id, {
                     "datetime_from": t_from,
                     "datetime_to": t_to,
@@ -549,8 +558,8 @@ def add_data(
     # Convert times to naive datetime, e.g.
     # {'utc': '2019-08-01T04:00:00Z', 'local': '2019-08-01T00:00:00-04:00'}}
     for col in ["time_from", "time_to"]:
-        for tz in ["utc", "local"]:
-            df[f"{col}_{tz}"] = pd.to_datetime(df[f"{col}_{tz}"]).dt.tz_localize(None)
+        df[f"{col}_utc"] = pd.to_datetime(df[f"{col}_utc"]).dt.tz_localize(None)
+        df[f"{col}_local"] = pd.to_datetime(df[f"{col}_local"].str.slice(0, 19))
 
     utcoffset = df["time_from_local"] - df["time_from_utc"]
 

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -191,44 +191,76 @@ def get_locations(**kwargs):
     some_scalars = [
         "id",
         "name",
-        "city",
-        "country",
-        # "entity",  # all null (from /measurements we do get values)
+        "locality",
+        "timezone",
         "isMobile",
-        # "isAnalysis",  # all null
-        # "sensorType",  # all null (from /measurements we do get values)
-        "firstUpdated",
-        "lastUpdated",
+        "isMonitor",
+        "distance",
     ]
+
+    # We will convert the keys of these dicts to columns
+    some_dicts = ["country", "owner", "provider"]
 
     data2 = []
     for d in data:
+        # Example (k v):
+        # - id 3
+        # - name NMA - Nima
+        # - locality None
+        # - timezone Africa/Accra
+        # - country {'id': 152, 'code': 'GH', 'name': 'Ghana'}
+        # - owner {'id': 4, 'name': 'Unknown Governmental Organization'}
+        # - provider {'id': 209, 'name': 'Dr. Raphael E. Arku and Colleagues'}
+        # - isMobile False
+        # - isMonitor True
+        # - instruments [{'id': 2, 'name': 'Government Monitor'}]
+        # - sensors [
+        #     {'id': 6, 'name': 'pm10 µg/m³', 'parameter': {'id': 1, 'name': 'pm10', 'units': 'µg/m³', 'displayName': 'PM10'}},
+        #     {'id': 5, 'name': 'pm25 µg/m³', 'parameter': {'id': 2, 'name': 'pm25', 'units': 'µg/m³', 'displayName': 'PM2.5'}}
+        #   ]
+        # - coordinates {'latitude': 5.58389, 'longitude': -0.19968}
+        # - licenses None
+        # - bounds [-0.19968, 5.58389, -0.19968, 5.58389]
+        # - distance None
+        # - datetimeFirst {'utc': '2016-03-23T20:00:00Z', 'local': '2016-03-23T15:00:00-05:00'}}
+        # - datetimeLast None
+
+        # Pull out some data
+        first_time = d["datetimeFirst"]
+        if first_time is not None:
+            first_time = first_time.get("utc", None)
+        last_time = d["datetimeLast"]
+        if last_time is not None:
+            last_time = last_time.get("utc", None)
         lat = d["coordinates"]["latitude"]
         lon = d["coordinates"]["longitude"]
-        parameters = [p["parameter"] for p in d["parameters"]]
-        mfs = d["manufacturers"]
-        if mfs:
-            manufacturer = mfs[0]["manufacturerName"]
-            if len(mfs) > 1:
-                logger.info(f"site {d['id']} has multiple manufacturers: {mfs}")
-        else:
-            manufacturer = None
+        parameters = [s["parameter"]["name"] for s in d["sensors"]]
+
+        # Start by taking selected scalars
         d2 = {k: d[k] for k in some_scalars}
+
+        # Convert some dict values to multiple columns
+        for k in some_dicts:
+            for kk, vv in d[k].items():
+                d2[f"{k}_{kk}"] = vv
+
         d2.update(
+            first_time=first_time,
+            last_time=last_time,
             latitude=lat,
             longitude=lon,
             parameters=parameters,
-            manufacturer=manufacturer,
         )
+
         data2.append(d2)
 
     df = pd.DataFrame(data2)
 
-    # Compute datetimes (the timestamps are already in UTC, but with tz specified)
-    assert df.firstUpdated.str.slice(-6, None).eq("+00:00").all()
-    df["firstUpdated"] = pd.to_datetime(df.firstUpdated.str.slice(0, -6))
-    assert df.lastUpdated.str.slice(-6, None).eq("+00:00").all()
-    df["lastUpdated"] = pd.to_datetime(df.lastUpdated.str.slice(0, -6))
+    # Compute datetimes
+    for col in ["first_time", "last_time"]:
+        i = df[col].notnull()
+        assert df.loc[i, col].str.slice(-1, None).eq("Z").all()
+        df[col] = pd.to_datetime(df[col].str.slice(0, -1))
 
     # Site ID
     df = df.rename(columns={"id": "siteid"})
@@ -238,7 +270,7 @@ def get_locations(**kwargs):
         logger.info(
             f"note: found {len(maybe_dupe_rows)} rows with duplicate site IDs:\n{maybe_dupe_rows}"
         )
-    df = df.drop_duplicates("siteid", keep="first").reset_index(drop=True)  # seem to be some dupes
+    df = df.drop_duplicates("siteid", keep="first").reset_index(drop=True)
 
     return df
 

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -154,13 +154,20 @@ def _consume(endpoint, *, params=None, timeout=10, retry=5, limit=500, npages=No
                 logger.info(f"request timed out (try {tries}/{retry})")
                 time.sleep(tries + 0.1 * rand())
             elif r.status_code == 429:
-                # Note: response headers don't seem to include Retry-After
-                # Just `{'detail': 'To many requests'}` in `.json()`
                 logger.info(f"rate limited (try {tries}/{retry})")
-                time.sleep(tries * 5 + 0.2 * rand())
+                ratelimit_reset = int(r.headers.get("X-Ratelimit-Reset", 60))
+                logger.info(f"sleeping for {ratelimit_reset} s (rate limit reset)")
+                time.sleep(ratelimit_reset + 0.1 * rand())
             else:
                 break
         r.raise_for_status()
+
+        ratelimit_remaining = int(r.headers["X-Ratelimit-Remaining"])
+        logger.info(f"rate limit count remaining: {ratelimit_remaining}")
+        if ratelimit_remaining < 1:
+            ratelimit_reset = int(r.headers["X-Ratelimit-Reset"])
+            logger.info(f"sleeping for {ratelimit_reset} s (rate limit reset)")
+            time.sleep(ratelimit_reset + 0.1 * rand())
 
         this_data = r.json()
         found = this_data["meta"]["found"]

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -399,6 +399,79 @@ def get_latlonbox_sites(latlonbox, **kwargs):
     return sites[in_box].reset_index(drop=True)
 
 
+def _to_wide_fmt(df):
+    # Normalize units
+    for vn, f in _PPM_TO_UGM3.items():
+        is_ug = (df.parameter == vn) & (df.units == "µg/m³")
+        df.loc[is_ug, "value"] /= f
+        df.loc[is_ug, "units"] = "ppm"
+
+    # Warn if inconsistent units
+    p_units = df.groupby("parameter").units.unique()
+    unique = p_units.apply(len).eq(1)
+    if not unique.all():
+        p_units_non_unique = p_units[~unique]
+        warnings.warn(f"inconsistent units among parameters:\n{p_units_non_unique}")
+
+    # Certain metadata should be unique for a given site but sometimes aren't
+    # (e.g. location names of different specificity, slight differences in lat/lon coords)
+    for col in ["latitude", "longitude"]:  # TODO: location name too
+        site_col = df.groupby("siteid")[col].unique()
+        unique = site_col.apply(len).eq(1)
+        if not unique.all():
+            site_col_non_unique = site_col[~unique]
+            warnings.warn(
+                f"non-unique {col!r} among site IDs:\n{site_col_non_unique}" "\nUsing first."
+            )
+            df = df.drop(columns=[col]).merge(
+                site_col.str.get(0),
+                left_on="siteid",
+                right_index=True,
+                how="left",
+            )
+
+    # Pivot
+    index = [
+        "siteid",
+        "time",
+        "latitude",
+        "longitude",
+        "time_local",
+        "utcoffset",
+        #
+        "country",
+        #
+        "sensor_id",
+        "is_mobile",
+        "is_monitor",
+        "period_label",
+    ]
+    assert sorted(index + ["parameter", "value", "units"]) == sorted(df.columns)
+
+    dupes = df[df.duplicated(keep=False)]
+    if not dupes.empty:
+        logging.info(f"found {len(dupes)} duplicated rows")
+    for col in index:
+        if df[col].isnull().all():
+            index.remove(col)
+            warnings.warn(f"dropping {col!r} from index for wide fmt (all null)")
+    df = (
+        df.drop_duplicates(keep="first")
+        .pivot_table(
+            values="value",
+            index=index,
+            columns="parameter",
+        )
+        .reset_index()
+    )
+
+    # Rename so that units are clear
+    df = df.rename(columns={p: f"{p}_ugm3" for p in _NON_MOLEC_PARAMS}, errors="ignore")
+    df = df.rename(columns={p: f"{p}_ppm" for p in _PPM_TO_UGM3}, errors="ignore")
+
+    return df
+
+
 @_api_key_warning
 def add_data(
     dates,
@@ -715,73 +788,6 @@ def add_data(
     df = df[col_order]
 
     if wide_fmt:
-        # Normalize units
-        for vn, f in _PPM_TO_UGM3.items():
-            is_ug = (df.parameter == vn) & (df.units == "µg/m³")
-            df.loc[is_ug, "value"] /= f
-            df.loc[is_ug, "unit"] = "ppm"
-
-        # Warn if inconsistent units
-        p_units = df.groupby("parameter").units.unique()
-        unique = p_units.apply(len).eq(1)
-        if not unique.all():
-            p_units_non_unique = p_units[~unique]
-            warnings.warn(f"inconsistent units among parameters:\n{p_units_non_unique}")
-
-        # Certain metadata should be unique for a given site but sometimes aren't
-        # (e.g. location names of different specificity, slight differences in lat/lon coords)
-        for col in ["location", "latitude", "longitude"]:
-            site_col = df.groupby("siteid")[col].unique()
-            unique = site_col.apply(len).eq(1)
-            if not unique.all():
-                site_col_non_unique = site_col[~unique]
-                warnings.warn(
-                    f"non-unique {col!r} among site IDs:\n{site_col_non_unique}" "\nUsing first."
-                )
-                df = df.drop(columns=[col]).merge(
-                    site_col.str.get(0),
-                    left_on="siteid",
-                    right_index=True,
-                    how="left",
-                )
-
-        # Pivot
-        index = [
-            "siteid",
-            "time",
-            "latitude",
-            "longitude",
-            "time_local",
-            "utcoffset",
-            #
-            "location",
-            "city",
-            "country",
-            #
-            "entity",
-            "sensor_type",
-            "is_mobile",
-            "is_analysis",
-        ]
-        dupes = df[df.duplicated(keep=False)]
-        if not dupes.empty:
-            logging.info(f"found {len(dupes)} duplicated rows")
-        for col in index:
-            if df[col].isnull().all():
-                index.remove(col)
-                warnings.warn(f"dropping {col!r} from index for wide fmt (all null)")
-        df = (
-            df.drop_duplicates(keep="first")
-            .pivot_table(
-                values="value",
-                index=index,
-                columns="parameter",
-            )
-            .reset_index()
-        )
-
-        # Rename so that units are clear
-        df = df.rename(columns={p: f"{p}_ugm3" for p in _NON_MOLEC_PARAMS}, errors="ignore")
-        df = df.rename(columns={p: f"{p}_ppm" for p in _PPM_TO_UGM3}, errors="ignore")
+        df = _to_wide_fmt(df)
 
     return df

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -238,7 +238,7 @@ def get_locations(**kwargs):
         sensor_ids = []
         for s in d["sensors"]:
             parameters.append(s["parameter"]["name"])
-            sensor_ids.append(s["id"])
+            sensor_ids.append([str(x) for x in s["id"]])
 
         # Start by taking selected scalars
         d2 = {k: d[k] for k in some_scalars}

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -653,7 +653,6 @@ def add_data(
     if entity is not None:
         raise NotImplementedError  # TODO: not sure what to use for this
     if sensor_type is not None:
-        # FIXME: may not be the best approach
         meta = meta.assign(
             sensor_type=meta["is_monitor"].map(
                 {

--- a/monetio/obs/openaq_v3.py
+++ b/monetio/obs/openaq_v3.py
@@ -18,10 +18,13 @@ import functools
 import logging
 import os
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import requests
+
+HERE = Path(__file__).parent
 
 logger = logging.getLogger(__name__)
 
@@ -184,9 +187,34 @@ def get_locations(**kwargs):
     https://api.openaq.org/docs#/v3/locations_get_v3_locations_get
     """
 
-    # TODO: multi-thread and/or cache to disk
+    import json
 
-    data = _consume(_ENDPOINTS["locations"], **kwargs)
+    from filelock import FileLock
+
+    kwargs["limit"] = kwargs.get("limit", 1000)
+
+    # TODO: gzip? or place in user cache dir instead?
+    p = HERE / "openaq_locations_data.json"
+    have_cache = False
+    if p.is_file():
+        now = pd.Timestamp.now(tz="UTC")
+        mtime = pd.Timestamp.fromtimestamp(p.stat().st_mtime, tz="UTC")
+        if now - mtime < pd.Timedelta(days=7):
+            have_cache = True
+        else:
+            logger.info(f"locations cache file is old ({mtime:%Y-%m-%d %H:%M:%SZ}), will refresh")
+    else:
+        logger.info("no locations cache file")
+
+    if not have_cache:
+        with FileLock(p.as_posix() + ".lock"):
+            data = _consume(_ENDPOINTS["locations"], **kwargs)
+            with open(p, "w") as f:
+                json.dump(data, f)
+    else:
+        logger.info("using cached locations data")
+        with open(p) as f:
+            data = json.load(f)
 
     # Some fields with scalar values to take
     some_scalars = [
@@ -475,7 +503,7 @@ def add_data(
 
     # Discover locations
     print("getting locations...")
-    meta = get_locations(npages=10)  # FIXME: arbitrary limit for testing
+    meta = get_locations()
     print(f"found {len(meta)} locations")
 
     # Narrow locations based on user input

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -62,8 +62,13 @@ def test_get_locations():
     # Check that we didn't end up with unexpected non-scalar columns
     for col in sites.columns:
         is_scalar = sites[col].apply(lambda x: pd.api.types.is_scalar(x)).all()
-        assert is_scalar or col in {"parameters", "sensor_ids"}
+        assert is_scalar or col in {"parameters", "parameter_ids", "sensor_ids"}
 
     # Check that pm25 and o3 are in the unique parameters
     unique_params = set(sites["parameters"].sum())
     assert {"pm25", "o3"} <= unique_params
+
+
+def test_get_sensors():
+    df = openaq.get_sensors(3832)
+    assert df.parameter.tolist() == ["so2", "o3"]

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -48,9 +48,9 @@ def test_get_parameters():
 
 
 def test_get_locations():
-    sites = openaq.get_locations(npages=2, limit=100)
+    sites = openaq.get_locations()
     assert_columns_all_snake_case(sites)
-    assert len(sites) <= 200
+    assert 10_000 <= len(sites) < 50_000
     assert sites.siteid.nunique() == len(sites)
     assert sites.dtypes["first_time"] == "datetime64[ns]"
     assert sites.dtypes["last_time"] == "datetime64[ns]"
@@ -70,5 +70,32 @@ def test_get_locations():
 
 
 def test_get_sensors():
-    df = openaq.get_sensors(3832)
+    df = openaq.get_sensors("3832")
+    assert_columns_all_snake_case(df)
     assert df.parameter.tolist() == ["so2", "o3"]
+
+
+def test_add_data_sensor_ids():
+    df = openaq.get_sensors("2978434")
+    sensor_ids = df["id"].tolist()
+    assert len(sensor_ids) == 1
+    df = openaq.add_data(
+        ["2024-08-01", "2024-08-08"],
+        query_time_split="1D",
+        sensor_ids=sensor_ids,
+        threads=2,
+    )
+    assert_columns_all_snake_case(df)
+    assert len(df) > 0
+
+
+def test_add_data_sensor_limit():
+    df = openaq.add_data(
+        ["2019-08-01", "2019-08-02"],
+        query_time_split=None,
+        sensor_limit=10,
+        threads=2,
+    )
+    assert_columns_all_snake_case(df)
+    assert len(df) > 0
+    assert df.sensor_id.nunique() <= 10

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -99,8 +99,8 @@ def test_add_data_sensor_ids(product):
 
     tmin, tmax = df.time.min(), df.time.max()
     if product == "raw":
-        assert tmin > pd.Timestamp("2024-08-01") - pd.Timedelta("1h")
-        assert tmax < pd.Timestamp("2024-08-08") + pd.Timedelta("1h")
+        assert tmin >= pd.Timestamp("2024-08-01")
+        assert tmax <= pd.Timestamp("2024-08-08")
     elif product in {"hourly", "daily"}:
         assert tmin == pd.Timestamp("2024-08-01")
         assert tmax == pd.Timestamp("2024-08-08")

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -86,10 +86,10 @@ def test_add_data_sensor_ids(product):
     assert len(sensor_ids) == 1
     df = openaq.add_data(
         ["2024-08-01", "2024-08-08"],
-        query_time_split="1D",
         raw=product == "raw",
         hourly=product == "hourly",
         daily=product == "daily",
+        query_time_split="1D",
         sensor_ids=sensor_ids,
         threads=2,
     )
@@ -108,9 +108,21 @@ def test_add_data_sensor_ids(product):
         raise AssertionError
 
 
-def test_add_data_sensor_limit():
+@pytest.mark.parametrize(
+    "product",
+    [
+        "raw",
+        "hourly",
+        "daily",
+    ],
+)
+def test_add_data_sensor_limit(product):
     df = openaq.add_data(
         ["2019-08-01", "2019-08-02"],
+        parameters="pm25",
+        raw=product == "raw",
+        hourly=product == "hourly",
+        daily=product == "daily",
         query_time_split=None,
         sensor_limit=10,
         threads=2,
@@ -120,4 +132,8 @@ def test_add_data_sensor_limit():
     assert df.sensor_id.nunique() <= 10
 
     df_wide = openaq._to_wide_fmt(df)
-    assert df.query("parameter == 'pm25'").value.mean() == df_wide.pm25_ugm3.mean()
+    assert df_wide.pm25_ugm3.mean() == pytest.approx(
+        df.query("parameter == 'pm25'").value.mean(),
+        rel=1e-15,
+        abs=0,
+    )

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -77,14 +77,7 @@ def test_get_sensors():
     [
         "raw",
         "hourly",
-        # "daily",
-        # FIXME: ^ weird results
-        # - time not floored to day (04:00:00)
-        #   - but it is for _local_ time
-        # -  2024-07-31 the first day
-        # - two different-valued pm25 records for each day even though just one sensor
-        #   - probably related to the time, multiple periods overlapping the request
-        #     and 1D time split -> doubled records
+        "daily",
     ],
 )
 def test_add_data_sensor_ids(product):

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -99,3 +99,6 @@ def test_add_data_sensor_limit():
     assert_columns_all_snake_case(df)
     assert len(df) > 0
     assert df.sensor_id.nunique() <= 10
+
+    df_wide = openaq._to_wide_fmt(df)
+    assert df.query("parameter == 'pm25'").value.mean() == df_wide.pm25_ugm3.mean()

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -72,21 +72,47 @@ def test_get_sensors():
     assert df.parameter.tolist() == ["so2", "o3"]
 
 
-def test_add_data_sensor_ids():
+@pytest.mark.parametrize(
+    "product",
+    [
+        "raw",
+        "hourly",
+        # "daily",
+        # FIXME: ^ weird results
+        # - time not floored to day (04:00:00)
+        #   - but it is for _local_ time
+        # -  2024-07-31 the first day
+        # - two different-valued pm25 records for each day even though just one sensor
+        #   - probably related to the time, multiple periods overlapping the request
+        #     and 1D time split -> doubled records
+    ],
+)
+def test_add_data_sensor_ids(product):
     df = openaq.get_sensors("2978434")
     sensor_ids = df["id"].tolist()
     assert len(sensor_ids) == 1
     df = openaq.add_data(
         ["2024-08-01", "2024-08-08"],
         query_time_split="1D",
+        raw=product == "raw",
+        hourly=product == "hourly",
+        daily=product == "daily",
         sensor_ids=sensor_ids,
         threads=2,
     )
     assert columns_all_snake_case(df)
     assert len(df) > 0
     assert df.sensor_id.nunique() == 1
-    assert df.time.min() > pd.Timestamp("2024-08-01") - pd.Timedelta("1h")
-    assert df.time.max() < pd.Timestamp("2024-08-08") + pd.Timedelta("1h")
+
+    tmin, tmax = df.time.min(), df.time.max()
+    if product == "raw":
+        assert tmin > pd.Timestamp("2024-08-01") - pd.Timedelta("1h")
+        assert tmax < pd.Timestamp("2024-08-08") + pd.Timedelta("1h")
+    elif product in {"hourly", "daily"}:
+        assert tmin == pd.Timestamp("2024-08-01")
+        assert tmax == pd.Timestamp("2024-08-08")
+    else:
+        raise AssertionError
 
 
 def test_add_data_sensor_limit():

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -5,9 +5,6 @@ import pytest
 
 import monetio.obs.openaq_v3 as openaq
 
-# TODO: check no camel case cols
-
-
 if (
     os.environ.get("CI", "false").lower() not in {"false", "0"}
     and os.environ.get("OPENAQ_API_KEY", "") == ""

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -84,6 +84,9 @@ def test_add_data_sensor_ids():
     )
     assert columns_all_snake_case(df)
     assert len(df) > 0
+    assert df.sensor_id.nunique() == 1
+    assert df.time.min() > pd.Timestamp("2024-08-01") - pd.Timedelta("1h")
+    assert df.time.max() < pd.Timestamp("2024-08-08") + pd.Timedelta("1h")
 
 
 def test_add_data_sensor_limit():

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -131,9 +131,27 @@ def test_add_data_sensor_limit(product):
     assert len(df) > 0
     assert df.sensor_id.nunique() <= 10
 
+    tmin, tmax = df.time.min(), df.time.max()
+    if product == "raw":
+        assert tmin >= pd.Timestamp("2019-08-01")
+        assert tmax <= pd.Timestamp("2019-08-02")
+    elif product in {"hourly", "daily"}:
+        assert tmin == pd.Timestamp("2019-08-01")
+        assert tmax == pd.Timestamp("2019-08-02")
+    else:
+        raise AssertionError
+
     df_wide = openaq._to_wide_fmt(df)
     assert df_wide.pm25_ugm3.mean() == pytest.approx(
         df.query("parameter == 'pm25'").value.mean(),
         rel=1e-15,
         abs=0,
     )
+
+
+def test_get_data_single_dt_single_site():
+    site = "843"
+    dates = "2023-08-01"
+    df = openaq.add_data(dates, parameters="o3", sites=site)
+    assert len(df) == 1
+    assert df.time.iloc[0] == pd.Timestamp("2023-08-01")

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -33,8 +33,13 @@ SITES_NEAR_NCWCP = [
 ]
 
 
+def assert_columns_all_snake_case(df):
+    assert all(df.columns.str.fullmatch(r"[a-z_]+"))
+
+
 def test_get_parameters():
     params = openaq.get_parameters()
+    assert_columns_all_snake_case(params)
     assert 20 <= len(params) <= 100
     assert params.id.nunique() == len(params)
     assert params.name.nunique() < len(params), "dupes for different units etc."
@@ -44,6 +49,7 @@ def test_get_parameters():
 
 def test_get_locations():
     sites = openaq.get_locations(npages=2, limit=100)
+    assert_columns_all_snake_case(sites)
     assert len(sites) <= 200
     assert sites.siteid.nunique() == len(sites)
     assert sites.dtypes["first_time"] == "datetime64[ns]"

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -30,13 +30,13 @@ SITES_NEAR_NCWCP = [
 ]
 
 
-def assert_columns_all_snake_case(df):
-    assert all(df.columns.str.fullmatch(r"[a-z_]+"))
+def columns_all_snake_case(df):
+    return all(df.columns.str.fullmatch(r"[a-z_]+"))
 
 
 def test_get_parameters():
     params = openaq.get_parameters()
-    assert_columns_all_snake_case(params)
+    assert columns_all_snake_case(params)
     assert 20 <= len(params) <= 100
     assert params.id.nunique() == len(params)
     assert params.name.nunique() < len(params), "dupes for different units etc."
@@ -46,7 +46,7 @@ def test_get_parameters():
 
 def test_get_locations():
     sites = openaq.get_locations()
-    assert_columns_all_snake_case(sites)
+    assert columns_all_snake_case(sites)
     assert 10_000 <= len(sites) < 50_000
     assert sites.siteid.nunique() == len(sites)
     assert sites.dtypes["first_time"] == "datetime64[ns]"
@@ -68,7 +68,7 @@ def test_get_locations():
 
 def test_get_sensors():
     df = openaq.get_sensors("3832")
-    assert_columns_all_snake_case(df)
+    assert columns_all_snake_case(df)
     assert df.parameter.tolist() == ["so2", "o3"]
 
 
@@ -82,7 +82,7 @@ def test_add_data_sensor_ids():
         sensor_ids=sensor_ids,
         threads=2,
     )
-    assert_columns_all_snake_case(df)
+    assert columns_all_snake_case(df)
     assert len(df) > 0
 
 
@@ -93,7 +93,7 @@ def test_add_data_sensor_limit():
         sensor_limit=10,
         threads=2,
     )
-    assert_columns_all_snake_case(df)
+    assert columns_all_snake_case(df)
     assert len(df) > 0
     assert df.sensor_id.nunique() <= 10
 

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -1,0 +1,63 @@
+import os
+
+import pandas as pd
+import pytest
+
+import monetio.obs.openaq_v3 as openaq
+
+# TODO: check no camel case cols
+
+
+if (
+    os.environ.get("CI", "false").lower() not in {"false", "0"}
+    and os.environ.get("OPENAQ_API_KEY", "") == ""
+):
+    # PRs from forks don't get the secret
+    pytest.skip("no API key", allow_module_level=True)
+
+LATLON_NCWCP = 38.9721, -76.9248
+SITES_NEAR_NCWCP = [
+    # AirGradient monitor
+    1236068,
+    1719392,
+    # # PurpleAir sensors
+    # 1118827,
+    # 357301,
+    # 273440,
+    # 271155,
+    # NASA GSFC
+    2978434,
+    # Beltsville (AirNow)
+    3832,
+    843,
+]
+
+
+def test_get_parameters():
+    params = openaq.get_parameters()
+    assert 20 <= len(params) <= 100
+    assert params.id.nunique() == len(params)
+    assert params.name.nunique() < len(params), "dupes for different units etc."
+    assert "pm25" in params.name.values
+    assert "o3" in params.name.values
+
+
+def test_get_locations():
+    sites = openaq.get_locations(npages=2, limit=100)
+    assert len(sites) <= 200
+    assert sites.siteid.nunique() == len(sites)
+    assert sites.dtypes["first_time"] == "datetime64[ns]"
+    assert sites.dtypes["last_time"] == "datetime64[ns]"
+    assert sites.dtypes["latitude"] == "float64"
+    assert sites.dtypes["longitude"] == "float64"
+    assert sites["latitude"].isnull().sum() == 0
+    assert sites["longitude"].isnull().sum() == 0
+
+    # Check that we didn't end up with unexpected non-scalar columns
+    for col in sites.columns:
+        is_scalar = sites[col].apply(lambda x: pd.api.types.is_scalar(x)).all()
+        assert is_scalar or col in {"parameters", "sensor_ids"}
+
+    # Check that pm25 and o3 are in the unique parameters
+    unique_params = set(sites["parameters"].sum())
+    assert {"pm25", "o3"} <= unique_params


### PR DESCRIPTION
Resolves #198 

Some changes from v2 to v3:
* Have to request data from each sensor separately
  - each sensor has data for one parameter (ID) only
  - to facilitate selecting by country, e.g., have to know all the available locations/sensors, which takes a minute or two to get (implemented caching to help)
* Some differences in the behavior wrt. specifying time period in the request
* No more search radius
* No more sensor type (low-cost vs reference-grade), just the `isMonitor` bool
* hourly- and daily-average data, in addition to raw
* ...

Note: `filelock` should be moved to the optional dependencies section of the Conda env spec and included in the conda-forge recipe.

cc: @jordanschnell