### PR TITLE
update ish and ish_lite urls 

### DIFF
--- a/monetio/obs/ish.py
+++ b/monetio/obs/ish.py
@@ -118,7 +118,7 @@ class ISH:
     WIDTHS = [width for _, _, width in _VAR_INFO]
 
     def __init__(self):
-        self.history_file = "https://www1.ncdc.noaa.gov/pub/data/noaa/isd-history.csv"
+        self.history_file = "https://www.ncei.noaa.gov/pub/data/noaa/isd-history.csv"
         self.history = None
         self.df = None
         self.dates = None
@@ -207,6 +207,9 @@ class ISH:
         URL is assumed if `url_or_file` is a string that starts with ``http``.
         """
         if isinstance(url_or_file, str) and url_or_file.startswith("http"):
+            # Normalize legacy NCDC host and bad redirect paths (prevents 404 on /pub/pub/)
+            url_or_file = url_or_file.replace("www1.ncdc.noaa.gov", "www.ncei.noaa.gov")
+            url_or_file = url_or_file.replace("/pub/pub/", "/pub/")
             import gzip
             import io
 
@@ -273,7 +276,16 @@ class ISH:
             dates = self.dates
 
         fname = self.history_file
-        self.history = pd.read_csv(fname, parse_dates=["BEGIN", "END"], infer_datetime_format=True)
+        try:
+            self.history = pd.read_csv(fname, parse_dates=["BEGIN", "END"])
+        except Exception:
+            # Fallback from legacy host to current NCEI host if needed
+            alt = fname.replace("www1.ncdc.noaa.gov", "www.ncei.noaa.gov")
+            if alt != fname:
+                self.history = pd.read_csv(alt, parse_dates=["BEGIN", "END"])
+                self.history_file = alt
+            else:
+                raise
         self.history.columns = [i.lower() for i in self.history.columns]
 
         if dates is not None:
@@ -408,7 +420,7 @@ class ISH:
                 self.df[group_cols + list(numeric_cols)]
                 .groupby("station_id")
                 .resample(window)
-                .mean(numeric_only=True)
+                .mean()
                 .reset_index()
             )
             # Merge back with non-numeric columns (e.g., time, station_id) if needed
@@ -497,7 +509,7 @@ class ISH:
         # fnames = []
         if self.verbose:
             print("Building ISH URLs...")
-        url = "https://www1.ncdc.noaa.gov/pub/data/noaa"
+        url = "https://www.ncei.noaa.gov/pub/data/noaa"
         # get each yearly urls available from the isd-lite site
         if len(unique_years) > 1:
             all_urls = []

--- a/monetio/obs/ish_lite.py
+++ b/monetio/obs/ish_lite.py
@@ -72,7 +72,7 @@ class ISH:
     """
 
     def __init__(self):
-        self.history_file = "https://www1.ncdc.noaa.gov/pub/data/noaa/isd-history.csv"
+        self.history_file = "https://www.ncei.noaa.gov/pub/data/noaa/isd-history.csv"
         self.history = None
         self.dates = None
         self.verbose = False
@@ -83,7 +83,7 @@ class ISH:
         setting the :attr:`history` attribute.
         If both are unset, you get the entire history file.
 
-        https://www1.ncdc.noaa.gov/pub/data/noaa/isd-history.csv
+        https://www.ncei.noaa.gov/pub/data/noaa/isd-history.csv
 
         The constructed 'station_id' column is a combination of the USAF and WBAN columns.
         This is done since USAF and WBAN alone are not unique in the history file.
@@ -98,7 +98,15 @@ class ISH:
             dates = self.dates
 
         fname = self.history_file
-        self.history = pd.read_csv(fname, parse_dates=["BEGIN", "END"], infer_datetime_format=True)
+        try:
+            self.history = pd.read_csv(fname, parse_dates=["BEGIN", "END"])
+        except Exception:
+            alt = fname.replace("www1.ncdc.noaa.gov", "www.ncei.noaa.gov")
+            if alt != fname:
+                self.history = pd.read_csv(alt, parse_dates=["BEGIN", "END"])
+                self.history_file = alt
+            else:
+                raise
         self.history.columns = [i.lower() for i in self.history.columns]
 
         if dates is not None:
@@ -146,7 +154,7 @@ class ISH:
         furls = []
         if self.verbose:
             print("Building ISH-Lite URLs...")
-        url = "https://www1.ncdc.noaa.gov/pub/data/noaa/isd-lite"
+        url = "https://www.ncei.noaa.gov/pub/data/noaa/isd-lite"
         # Get each yearly urls available from the isd-lite site
         if len(unique_years) > 1:
             all_urls = []
@@ -317,13 +325,8 @@ class ISH:
 
         if resample and not df.empty:
             print("Resampling to every " + window)
-            df = (
-                df.set_index("time")
-                .groupby("siteid")
-                .resample(window)
-                .mean(numeric_only=True)
-                .reset_index()
-            )
+            df = df.set_index("time").groupby("siteid").resample(window).mean().reset_index()
+            # TODO: mean(numeric_only=True)
 
         # Add site metadata
         df = pd.merge(df, dfloc, how="left", left_on="siteid", right_on="station_id").rename(


### PR DESCRIPTION
This pull request updates the NOAA ISH and ISH-Lite data ingestion modules to use the new NCEI data host, improves robustness to host changes, and updates data aggregation to maintain compatibility with recent pandas versions. The most important changes are grouped below.

**Host migration and URL normalization:**

* Updated all hardcoded URLs and default `history_file` values from `www1.ncdc.noaa.gov` to `www.ncei.noaa.gov` in both `ish.py` and `ish_lite.py` to use the current NCEI data host. [[1]](diffhunk://#diff-99e9c90274f4b01de8941c36896a5a3ef514ede86a8ef5ccda6fa45b57bb776fL121-R121) [[2]](diffhunk://#diff-99e9c90274f4b01de8941c36896a5a3ef514ede86a8ef5ccda6fa45b57bb776fL500-R512) [[3]](diffhunk://#diff-24b800dde30ce8d721e4d0c32aca9730c823bd98ac30626a6e09109d93f6dd3bL75-R75) [[4]](diffhunk://#diff-24b800dde30ce8d721e4d0c32aca9730c823bd98ac30626a6e09109d93f6dd3bL149-R157)
* Added logic to normalize legacy hostnames and fix bad redirect paths (e.g., `/pub/pub/` to `/pub/`) when reading data from URLs, preventing 404 errors due to outdated links.

**Robustness in reading history files:**

* Improved `read_ish_history` in both modules to catch exceptions when reading from the old host, automatically retrying with the new NCEI host if necessary. The `history_file` attribute is updated accordingly. [[1]](diffhunk://#diff-99e9c90274f4b01de8941c36896a5a3ef514ede86a8ef5ccda6fa45b57bb776fL276-R288) [[2]](diffhunk://#diff-24b800dde30ce8d721e4d0c32aca9730c823bd98ac30626a6e09109d93f6dd3bL101-R109)

**Data aggregation compatibility:**

* Removed `numeric_only=True` from `.mean()` calls when resampling data frames, ensuring compatibility with recent pandas versions and avoiding warnings or errors. [[1]](diffhunk://#diff-99e9c90274f4b01de8941c36896a5a3ef514ede86a8ef5ccda6fa45b57bb776fL411-R423) [[2]](diffhunk://#diff-24b800dde30ce8d721e4d0c32aca9730c823bd98ac30626a6e09109d93f6dd3bL320-R329)

**Documentation updates:**

* Updated docstrings and inline comments to reference the new NCEI URLs for clarity and accuracy.