### PR TITLE
Work within the AERONET limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,21 @@ jobs:
       - name: Install the package (editable)
         run: pip install -e . --no-deps -vv
 
+      - name: Set AERONET test flag
+        run: |
+          if [[ "${{ matrix.python-version }}" == "3.11" && "${{ matrix.pandas-version }}" == "2" ]]; then
+            echo "AERONET_IGNORE=" >> $GITHUB_ENV
+          else
+            echo "AERONET_IGNORE=--ignore=tests/test_aeronet.py" >> $GITHUB_ENV
+          fi
+
       - name: Test with pytest
-        run: pytest -n auto --dist loadgroup -v -ra -W "ignore:Downloading test file:UserWarning::"
+        run: pytest -n auto --dist loadgroup -v -ra "$AERONET_IGNORE" -W "ignore:Downloading test file:UserWarning::"
 
       - name: Test with pytspack installed
         run: |
           pip install https://github.com/noaa-oar-arl/pytspack/archive/master.zip
-          pytest -k with_pytspack -n auto -v -ra -W "ignore:API key length is 0:UserWarning::"
+          pytest -k with_pytspack -n auto -v -ra "$AERONET_IGNORE" -W "ignore:API key length is 0:UserWarning::"
 
   docs:
     name: Check docs build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
           fi
 
       - name: Test with pytest
-        run: pytest -n auto --dist loadgroup -v -ra "$AERONET_IGNORE" -W "ignore:Downloading test file:UserWarning::"
+        run: pytest -n auto --dist loadgroup -v -ra $AERONET_IGNORE
+          -W "ignore:Downloading test file:UserWarning::"
+          -W "ignore:API key length is 0:UserWarning::"
 
       - name: Test with pytspack installed
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     name: Test (Py ${{ matrix.python-version }}, pd ${{ matrix.pandas-version }})
     runs-on: ubuntu-latest
     if: github.repository == 'noaa-oar-arl/monetio'
+    env:
+      AERONET_TEST_FILE: tests/test_aeronet.py
     strategy:
       matrix:
         include:
@@ -55,15 +57,21 @@ jobs:
           if [[ "${{ matrix.python-version }}" == "3.11" && "${{ matrix.pandas-version }}" == "2" ]]; then
             echo "AERONET_IGNORE=" >> $GITHUB_ENV
           else
-            echo "AERONET_IGNORE=--ignore=tests/test_aeronet.py" >> $GITHUB_ENV
+            echo "AERONET_IGNORE=--ignore=${AERONET_TEST_FILE}" >> $GITHUB_ENV
           fi
 
-      - name: Test with pytest
+      - name: Test with pytest (main run)
         run: pytest -n auto --dist loadgroup -v -ra $AERONET_IGNORE
           -W "ignore:Downloading test file:UserWarning::"
           -W "ignore:API key length is 0:UserWarning::"
 
-      - name: Test with pytspack installed
+      - name: Test AERONET non-web
+        run: |
+          if [[ -n "$AERONET_IGNORE" ]]; then
+            pytest -m "not web" -n auto --dist loadgroup -v -ra "$AERONET_TEST_FILE"
+          fi
+
+      - name: Test with pytspack
         run: |
           if [[ -z "$AERONET_IGNORE" ]]; then
             pip install https://github.com/noaa-oar-arl/pytspack/archive/master.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,10 @@ jobs:
 
       - name: Test with pytspack installed
         run: |
-          pip install https://github.com/noaa-oar-arl/pytspack/archive/master.zip
-          pytest -k with_pytspack -n auto -v -ra "$AERONET_IGNORE" -W "ignore:API key length is 0:UserWarning::"
+          if [[ -z "$AERONET_IGNORE" ]]; then
+            pip install https://github.com/noaa-oar-arl/pytspack/archive/master.zip
+            pytest -k with_pytspack -n auto -v -ra -W "ignore:API key length is 0:UserWarning::"
+          fi
 
   docs:
     name: Check docs build

--- a/monetio/obs/aeronet.py
+++ b/monetio/obs/aeronet.py
@@ -437,14 +437,14 @@ class AERONET:
         if isinstance(self.url, str) and self.url.startswith("http"):
             time.sleep(6)  # rate limit: max 10 hits/min
         df.rename(columns=str.lower, inplace=True)
-        date_col, time_col = df.columns[1], df.columns[2]
         df = pd.concat(
             [
                 df.iloc[:, :1],
-                pd.to_datetime(df[date_col] + df[time_col], format=r"%d:%m:%Y%H:%M:%S").rename(
-                    "time"
-                ),
-                df.drop(columns=[date_col, time_col]).iloc[:, 1:],
+                pd.to_datetime(
+                    df.iloc[:, 1] + df.iloc[:, 2],
+                    format=r"%d:%m:%Y%H:%M:%S",
+                ).rename("time"),
+                df.iloc[:, 3:],
             ],
             axis=1,
         )

--- a/monetio/obs/aeronet.py
+++ b/monetio/obs/aeronet.py
@@ -431,12 +431,16 @@ class AERONET:
             time.sleep(6)  # rate limit: max 10 hits/min
         df.rename(columns=str.lower, inplace=True)
         date_col, time_col = df.columns[1], df.columns[2]
-        df.insert(
-            1,
-            "time",
-            pd.to_datetime(df[date_col] + " " + df[time_col], format=r"%d:%m:%Y %H:%M:%S"),
+        df = pd.concat(
+            [
+                df.iloc[:, :1],
+                pd.to_datetime(df[date_col] + df[time_col], format=r"%d:%m:%Y%H:%M:%S").rename(
+                    "time"
+                ),
+                df.drop(columns=[date_col, time_col]).iloc[:, 1:],
+            ],
+            axis=1,
         )
-        df = df.drop(columns=[date_col, time_col])
         df.rename(
             columns={
                 "aeronet_site": "siteid",

--- a/monetio/obs/aeronet.py
+++ b/monetio/obs/aeronet.py
@@ -154,6 +154,13 @@ def add_data(
         interp_to_aod_values=interp_to_aod_values,
     )
 
+    if n_procs > 1:
+        warnings.warn(
+            "Parallel processing may lead to rate-limiting or blocking by AERONET. "
+            "Consider the default n_procs=1 if you encounter issues.",
+            stacklevel=2,
+        )
+
     requested_parallel = n_procs != 1
 
     # Split up by day

--- a/monetio/obs/aeronet.py
+++ b/monetio/obs/aeronet.py
@@ -392,9 +392,9 @@ class AERONET:
         if isinstance(self.url, str) and self.url.startswith("http"):
             import requests
 
-            r = requests.get(self.url, stream=True, timeout=60)
-            r.raise_for_status()
-            s = "\n".join(islice(r.iter_lines(decode_unicode=True), n))
+            with requests.get(self.url, stream=True, timeout=60) as r:
+                r.raise_for_status()
+                s = "\n".join(islice(r.iter_lines(decode_unicode=True), n))
             time.sleep(6)  # rate limit: max 10 hits/min
         else:
             with open(self.url) as f:

--- a/monetio/obs/aeronet.py
+++ b/monetio/obs/aeronet.py
@@ -2,6 +2,7 @@
 AERONET
 """
 
+import time
 import warnings
 from datetime import datetime
 from functools import lru_cache
@@ -199,7 +200,9 @@ def get_valid_sites():
         df = pd.read_csv(
             "https://aeronet.gsfc.nasa.gov/aeronet_locations_v3.txt",
             skiprows=1,
-        ).rename(
+        )
+        time.sleep(6)  # rate limit: max 10 hits/min
+        df = df.rename(
             columns={
                 "Site_Name": "siteid",
                 "Longitude(decimal_degrees)": "longitude",
@@ -392,6 +395,7 @@ class AERONET:
             r = requests.get(self.url, stream=True, timeout=60)
             r.raise_for_status()
             s = "\n".join(islice(r.iter_lines(decode_unicode=True), n))
+            time.sleep(6)  # rate limit: max 10 hits/min
         else:
             with open(self.url) as f:
                 s = "\n".join(islice(f, n))
@@ -423,11 +427,16 @@ class AERONET:
             # ^ SDA header is missing one column (80 vs 81 in data) and we lose one making 'time'
             na_values=-999,
         )
+        if isinstance(self.url, str) and self.url.startswith("http"):
+            time.sleep(6)  # rate limit: max 10 hits/min
         df.rename(columns=str.lower, inplace=True)
         date_col, time_col = df.columns[1], df.columns[2]
-        time = pd.to_datetime(df[date_col] + " " + df[time_col], format=r"%d:%m:%Y %H:%M:%S")
+        df.insert(
+            1,
+            "time",
+            pd.to_datetime(df[date_col] + " " + df[time_col], format=r"%d:%m:%Y %H:%M:%S"),
+        )
         df = df.drop(columns=[date_col, time_col])
-        df.insert(1, "time", time)
         df.rename(
             columns={
                 "aeronet_site": "siteid",

--- a/monetio/obs/aeronet.py
+++ b/monetio/obs/aeronet.py
@@ -389,7 +389,7 @@ class AERONET:
         if isinstance(self.url, str) and self.url.startswith("http"):
             import requests
 
-            r = requests.get(self.url, stream=True)
+            r = requests.get(self.url, stream=True, timeout=60)
             r.raise_for_status()
             s = "\n".join(islice(r.iter_lines(decode_unicode=True), n))
         else:

--- a/monetio/obs/ish_lite.py
+++ b/monetio/obs/ish_lite.py
@@ -218,9 +218,8 @@ class ISH:
             names=columns,
         )
         time_vars = ["year", "month", "day", "hour"]
-        time = pd.to_datetime(df[time_vars])
+        df.insert(0, "time", pd.to_datetime(df[time_vars]))
         df = df.drop(columns=time_vars)
-        df.insert(0, "time", time)
         filename = fname.split("/")[-1].split("-")
         siteid = filename[0] + filename[1]
         df["temp"] /= 10.0

--- a/monetio/util.py
+++ b/monetio/util.py
@@ -378,6 +378,13 @@ def _import_required(mod_name: str):
         ) from e
 
 
+def _on_ci():
+    """Return True if running in a CI environment."""
+    import os
+
+    return os.environ.get("CI", "false").lower() in {"true", "yes", "1", ""}
+
+
 def _get_pandas_version():
     """Major and minor."""
     import pandas as pd

--- a/monetio/util.py
+++ b/monetio/util.py
@@ -382,7 +382,7 @@ def _on_ci():
     """Return True if running in a CI environment."""
     import os
 
-    return os.environ.get("CI", "false").lower() in {"true", "yes", "1", ""}
+    return os.environ.get("CI", "false").lower() not in {"false", "0"}
 
 
 def _get_pandas_version():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,6 @@ filterwarnings = [
     "ignore:np.find_common_type is deprecated.:DeprecationWarning::",
     "ignore:The current Dask DataFrame implementation is deprecated.:DeprecationWarning::",
 ]
+markers = [
+    "web: marks tests that require web access to run",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
-import os
 from pathlib import Path
 
 import pytest
 
+from monetio.util import _on_ci
+
 
 @pytest.fixture(scope="session")
 def is_ci():
-    return os.environ.get("CI", "false").lower() in {"true", "yes", "1", ""}
+    return _on_ci()
 
 
 @pytest.fixture

--- a/tests/test_aeronet.py
+++ b/tests/test_aeronet.py
@@ -1,6 +1,20 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
 import pytest
 
+from monetio.obs import aeronet
 from monetio.util import _on_ci
+
+try:
+    import pytspack  # noqa: F401
+except ImportError:
+    has_pytspack = False
+else:
+    has_pytspack = True
+
+DATA = Path(__file__).parent / "data"
 
 # We try the tests in CI (one matrix case)
 # but realize rate limiting may occur or shared CI IPs may be/get blocked.
@@ -9,24 +23,12 @@ xfail_on_ci = pytest.mark.xfail(
     reason="AERONET access can be rate-limited on CI",
     strict=False,
 )
+web_group = pytest.mark.xdist_group(name="aeronet-web")
 
-pytestmark = xfail_on_ci
 
-from pathlib import Path
-
-import numpy as np
-import pandas as pd
-
-from monetio import aeronet
-
-DATA = Path(__file__).parent / "data"
-
-try:
-    import pytspack  # noqa: F401
-except ImportError:
-    has_pytspack = False
-else:
-    has_pytspack = True
+def web(test_func):
+    """Marker for tests that access the AERONET website."""
+    return pytest.mark.web(xfail_on_ci(web_group(test_func)))
 
 
 def test_build_url_required_param_checks():
@@ -82,17 +84,20 @@ def test_build_url_bad_prod():
     a.build_url()
 
 
+@web
 def test_valid_sites_col_rename():
     assert (
         aeronet.get_valid_sites().columns == ["siteid", "longitude", "latitude", "elevation"]
     ).all()
 
 
+@web
 def test_add_data_bad_siteid():
     with pytest.raises(ValueError, match="invalid site"):
         aeronet.add_data(siteid="Rivendell")
 
 
+@web
 def test_add_data_one_site():
     dates = pd.date_range("2021/08/01", "2021/08/03")
     df = aeronet.add_data(dates, siteid="SERC")
@@ -101,6 +106,7 @@ def test_add_data_one_site():
     assert df.attrs["info"].startswith("AERONET Data Download")
 
 
+@web
 def test_add_data_inv():
     dates = pd.date_range("2021/08/01", "2021/08/02")
 
@@ -115,6 +121,7 @@ def test_add_data_inv():
     # TODO: find a time with Level 2.0 retrievals
 
 
+@web
 @pytest.mark.parametrize("product", aeronet.AERONET._valid_prod_noninv)
 def test_add_data_all_noninv(product):
     dates = pd.date_range("2021/08/01", "2021/08/02")
@@ -124,6 +131,7 @@ def test_add_data_all_noninv(product):
     assert df.index.size > 0
 
 
+@web
 def test_add_data_valid_empty_query():
     dates = pd.date_range("2021/08/01", "2021/08/02")
     site = "Banana_River"
@@ -165,6 +173,7 @@ def test_load_local_inv():
     assert (df.siteid == "Cart_Site").all(axis=0)
 
 
+@web
 def test_add_data_lunar():
     dates = pd.date_range("2021/08/01", "2021/08/02")
     df = aeronet.add_data(dates, lunar=True, daily=True)  # only daily-average data at this time
@@ -175,6 +184,7 @@ def test_add_data_lunar():
     assert df.index.size > 0
 
 
+@web
 def test_serial_freq():
     # For MM data proc example
     dates = pd.date_range(start="2019-09-01", end="2019-09-2", freq="h")
@@ -185,6 +195,7 @@ def test_serial_freq():
     ).all()
 
 
+@web
 @pytest.mark.skipif(has_pytspack, reason="has pytspack")
 def test_interp_without_pytspack():
     # For MM data proc example
@@ -194,6 +205,7 @@ def test_interp_without_pytspack():
         aeronet.add_data(dates, n_procs=1, interp_to_aod_values=standard_wavelengths)
 
 
+@web
 @pytest.mark.skipif(not has_pytspack, reason="no pytspack")
 def test_interp_with_pytspack():
     # For MM data proc example
@@ -229,6 +241,7 @@ def test_interp_with_pytspack():
     }
 
 
+@web
 @pytest.mark.skipif(not has_pytspack, reason="no pytspack")
 def test_interp_daily_with_pytspack():
     dates = pd.date_range(start="2019-09-01", end="2019-09-2", freq="h")
@@ -238,6 +251,7 @@ def test_interp_daily_with_pytspack():
     assert {f"aod_{int(wl)}nm" for wl in standard_wavelengths}.issubset(df.columns)
 
 
+@web
 @pytest.mark.parametrize(
     "dates",
     [

--- a/tests/test_aeronet.py
+++ b/tests/test_aeronet.py
@@ -1,11 +1,11 @@
-import os
-
 import pytest
 
+from monetio.util import _on_ci
+
 # We try the tests in CI (one matrix case)
-# but realize rate limting may occur or shared CI IPs may be/get blocked.
+# but realize rate limiting may occur or shared CI IPs may be/get blocked.
 xfail_on_ci = pytest.mark.xfail(
-    os.environ.get("CI", "false").lower() == "true",
+    _on_ci(),
     reason="AERONET access can be rate-limited on CI",
     strict=False,
 )

--- a/tests/test_aeronet.py
+++ b/tests/test_aeronet.py
@@ -2,20 +2,20 @@ import os
 
 import pytest
 
-# TODO: Skip on CI until we can fix this with NASA.  NASA seems to be blocking requests from CI IPs.
-# This is a temporary solution until we can resolve the issue with NASA.
-# If you are running this locally, you can remove the skip decorator.
-skip_on_ci = pytest.mark.skipif(
-    os.environ.get("CI", "false").lower() == "true", reason="Skipped on CI"
+# We try the tests in CI (one matrix case)
+# but realize rate limting may occur or shared CI IPs may be/get blocked.
+xfail_on_ci = pytest.mark.xfail(
+    os.environ.get("CI", "false").lower() == "true",
+    reason="AERONET access can be rate-limited on CI",
+    strict=False,
 )
 
-pytestmark = skip_on_ci
+pytestmark = xfail_on_ci
 
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from monetio import aeronet
 

--- a/tests/test_aeronet.py
+++ b/tests/test_aeronet.py
@@ -149,7 +149,7 @@ def test_load_local():
 
     df = aeronet.add_local(fp)
     assert df.index.size > 0
-    assert (df.siteid == "Mauna_Loa").all(0)
+    assert (df.siteid == "Mauna_Loa").all(axis=0)
     assert df.attrs["info"].startswith("AERONET Data Download")
 
 
@@ -162,7 +162,7 @@ def test_load_local_inv():
 
     df = aeronet.add_local(fp)
     assert df.index.size > 0
-    assert (df.siteid == "Cart_Site").all(0)
+    assert (df.siteid == "Cart_Site").all(axis=0)
 
 
 def test_add_data_lunar():

--- a/tests/test_aeronet.py
+++ b/tests/test_aeronet.py
@@ -253,7 +253,8 @@ def test_interp_daily_with_pytspack():
 )
 def test_issue100(dates, request):
     df1 = aeronet.add_data(dates, n_procs=1)
-    df2 = aeronet.add_data(dates, n_procs=2)
+    with pytest.warns(UserWarning, match="Parallel processing may lead to rate-limiting"):
+        df2 = aeronet.add_data(dates, n_procs=2)
     assert len(df1) == len(df2)
     if request.node.callspec.id == "two days":
         # Sort first (can use `df1.compare(df2)` for debugging)

--- a/tests/test_cesm_fv_updated.py
+++ b/tests/test_cesm_fv_updated.py
@@ -11,7 +11,7 @@ from monetio.models._cesm_fv_mm import _calc_pressure, _calc_pressure_i, open_mf
 
 HERE = Path(__file__).parent
 
-cesm_xdist = pytest.mark.xdist_group(name="retrieve-files")
+cesm_xdist = pytest.mark.xdist_group(name="cesm-fv-retrieve-file")
 
 
 def retrieve_test_file():

--- a/tests/test_gml_ozonesonde.py
+++ b/tests/test_gml_ozonesonde.py
@@ -3,7 +3,7 @@ import pytest
 
 from monetio import gml_ozonesonde
 
-uses_get_files = pytest.mark.xdist_group(name="get-files")
+uses_get_files = pytest.mark.xdist_group(name="gml-ozonesonde-get-files")
 
 
 @uses_get_files

--- a/tests/test_openaq_v2.py
+++ b/tests/test_openaq_v2.py
@@ -6,14 +6,11 @@ import pytest
 import requests
 
 import monetio.obs.openaq_v2 as openaq
-from monetio.util import _get_pandas_version
+from monetio.util import _get_pandas_version, _on_ci
 
 PD_GTE_3 = _get_pandas_version() >= (3, 0)
 
-if (
-    os.environ.get("CI", "false").lower() not in {"false", "0"}
-    and os.environ.get("OPENAQ_API_KEY", "") == ""
-):
+if _on_ci() and os.environ.get("OPENAQ_API_KEY", "") == "":
     # PRs from forks don't get the secret
     pytest.skip("no API key", allow_module_level=True)
 

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -4,14 +4,11 @@ import pandas as pd
 import pytest
 
 import monetio.obs.openaq_v3 as openaq
-from monetio.util import _get_pandas_version
+from monetio.util import _get_pandas_version, _on_ci
 
 PD_GTE_3 = _get_pandas_version() >= (3, 0)
 
-if (
-    os.environ.get("CI", "false").lower() not in {"false", "0"}
-    and os.environ.get("OPENAQ_API_KEY", "") == ""
-):
+if _on_ci() and os.environ.get("OPENAQ_API_KEY", "") == "":
     # PRs from forks don't get the secret
     pytest.skip("no API key", allow_module_level=True)
 


### PR DESCRIPTION
Using a simple method (wait 6 seconds every time we hit the site). And in CI only run the AERONET tests with one matrix case (Python 3.11, pandas 2, like the docs env).

Not as fancy than the #260 solution, but seems to work as a band-aid for now. Tested on Gaea with pandas 2 and 3.

<details>

From <https://aeronet.gsfc.nasa.gov/>:

<img width="557" height="350" alt="image" src="https://github.com/user-attachments/assets/56b346ed-f62d-47e1-b6a8-f891ab6edb54" />
</details>