### PR TITLE
Reduce OpenAQ CI usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
           fi
 
       - name: Test with pytest (main run)
-        run: pytest -n auto --dist loadgroup -v -ra $AERONET_IGNORE $OPENAQ_IGNORE
+        run: >-
+          pytest -n auto --dist loadgroup -v -ra $AERONET_IGNORE $OPENAQ_IGNORE
           -W "ignore:Downloading test file:UserWarning::"
           -W "ignore:API key length is 0:UserWarning::"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     if: github.repository == 'noaa-oar-arl/monetio'
     env:
       AERONET_TEST_FILE: tests/test_aeronet.py
+      OPENAQ_WEB_API_TEST_FILES: tests/test_openaq_v2.py tests/test_openaq_v3.py
     strategy:
       matrix:
         include:
@@ -52,16 +53,22 @@ jobs:
       - name: Install the package (editable)
         run: pip install -e . --no-deps -vv
 
-      - name: Set AERONET test flag
+      - name: Set test flags
         run: |
           if [[ "${{ matrix.python-version }}" == "3.11" && "${{ matrix.pandas-version }}" == "2" ]]; then
             echo "AERONET_IGNORE=" >> $GITHUB_ENV
+            echo "OPENAQ_IGNORE=" >> $GITHUB_ENV
           else
             echo "AERONET_IGNORE=--ignore=${AERONET_TEST_FILE}" >> $GITHUB_ENV
+            OPENAQ_IGNORE_ARGS=""
+            for f in $OPENAQ_WEB_API_TEST_FILES; do
+              OPENAQ_IGNORE_ARGS="$OPENAQ_IGNORE_ARGS --ignore=$f"
+            done
+            echo "OPENAQ_IGNORE=${OPENAQ_IGNORE_ARGS}" >> $GITHUB_ENV
           fi
 
       - name: Test with pytest (main run)
-        run: pytest -n auto --dist loadgroup -v -ra $AERONET_IGNORE
+        run: pytest -n auto --dist loadgroup -v -ra $AERONET_IGNORE $OPENAQ_IGNORE
           -W "ignore:Downloading test file:UserWarning::"
           -W "ignore:API key length is 0:UserWarning::"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,6 @@ repos:
           - --ignore=E203,E402,E501,W503,E226
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.8.1"
+    rev: "v3.8.3"
     hooks:
       - id: prettier

--- a/tests/test_openaq_v2.py
+++ b/tests/test_openaq_v2.py
@@ -37,6 +37,8 @@ xfail_httperror = pytest.mark.xfail(
     strict=True,
 )
 
+web_api = pytest.mark.xdist_group(name="openaq-web-api")
+
 
 @contextmanager
 def check_error_code():
@@ -50,6 +52,7 @@ def check_error_code():
         raise AssertionError(f"expected HTTP Error {should_raise}") from e
 
 
+@web_api
 @xfail_httperror
 def test_get_parameters():
     with check_error_code():
@@ -61,6 +64,7 @@ def test_get_parameters():
     assert "o3" in params.name.values
 
 
+@web_api
 @xfail_httperror
 def test_get_locations():
     with check_error_code():
@@ -75,6 +79,7 @@ def test_get_locations():
     assert sites["longitude"].isnull().sum() == 0
 
 
+@web_api
 @xfail_httperror
 def test_get_data_near_ncwcp_sites():
     sites = SITES_NEAR_NCWCP
@@ -90,6 +95,7 @@ def test_get_data_near_ncwcp_sites():
     assert not df.value.isna().all() and not df.value.lt(0).any()
 
 
+@web_api
 @xfail_httperror
 def test_get_data_near_ncwcp_sites_wide():
     sites = SITES_NEAR_NCWCP
@@ -103,6 +109,7 @@ def test_get_data_near_ncwcp_sites_wide():
     assert not {"parameter", "value", "unit"} <= set(df.columns)
 
 
+@web_api
 @xfail_httperror
 def test_get_data_near_ncwcp_search_radius():
     latlon = LATLON_NCWCP
@@ -118,6 +125,7 @@ def test_get_data_near_ncwcp_search_radius():
     assert df.entity.eq("Governmental Organization").all()
 
 
+@web_api
 @xfail_httperror
 def test_get_data_near_ncwcp_sensor_type():
     latlon = LATLON_NCWCP
@@ -128,6 +136,7 @@ def test_get_data_near_ncwcp_sensor_type():
     assert df.sensor_type.eq("low-cost sensor").all()
 
 
+@web_api
 @xfail_httperror
 def test_get_data_single_dt_single_site():
     site = 843
@@ -137,6 +146,7 @@ def test_get_data_single_dt_single_site():
     assert len(df) == 1
 
 
+@web_api
 @xfail_httperror
 @pytest.mark.parametrize(
     "entity",

--- a/tests/test_openaq_v3.py
+++ b/tests/test_openaq_v3.py
@@ -29,6 +29,8 @@ SITES_NEAR_NCWCP = [
     843,
 ]
 
+pytestmark = pytest.mark.xdist_group(name="openaq-web-api")
+
 
 def columns_all_snake_case(df):
     return all(df.columns.str.fullmatch(r"[a-z_]+"))


### PR DESCRIPTION
Our API key was recently automatically disabled for going over limits. We do already proactively use the response rate limit info to wait, but CI has concurrent matrix runs (now it doesn't). Here we also make sure that one xdist worker runs all the tests. And the API key was rotated.