### PR TITLE
sat: add propagating min/max QA screens to TEMPO/TROPOMI L2 readers

### DIFF
--- a/monetio/sat/tempo_l2.py
+++ b/monetio/sat/tempo_l2.py
@@ -17,131 +17,138 @@ import xarray as xr
 from cftime import num2pydate
 from netCDF4 import Dataset
 
-
-def _open_one_dataset(fname, variable_dict):
+def _open_one_dataset(fname, variable_dict, i=None):
     """Read locally stored INTELSAT TEMPO NO2 level 2
 
-    Parameters
-    ----------
-    fname : str
-        Local path to netCDF4 (HDF5) file.
-    variable_dict : dict
+    Making this function less memory intensive (hopefully)
 
-    Returns
-    -------
-    ds : xr.Dataset
+    original of this was from Peizhi Hao: https://github.com/PeizhiHao71/monetio_cesm_se_regrid/blob/cesm-se-regrid-support/monetio/models/_cesm_se_mm.py
     """
-    print("reading " + fname)
+
+    # Print only every 75 files (when index is provided)
+    if i is not None and i % 75 == 0:
+        print(f"reading {fname}", flush=True)
 
     ds = xr.Dataset()
 
-    dso = Dataset(fname, "r")
-    lon_var = dso.groups["geolocation"]["longitude"]
-    lat_var = dso.groups["geolocation"]["latitude"]
-    time_var = dso.groups["geolocation"]["time"]
-    time_units = time_var.units
+    with Dataset(fname, "r") as dso:
 
-    ds["lon"] = (
-        ("x", "y"),
-        lon_var[:].squeeze(),
-        {"long_name": lon_var.long_name, "units": lon_var.units},
-    )
-    ds["lat"] = (
-        ("x", "y"),
-        lat_var[:].squeeze(),
-        {"long_name": lat_var.long_name, "units": lat_var.units},
-    )
-    ds["time"] = (
-        ("time",),
-        num2pydate(time_var[:].squeeze(), time_units),
-        {"long_name": time_var.long_name},
-    )
-    ds = ds.set_coords(["time", "lon", "lat"])
+        lon_var = dso.groups["geolocation"]["longitude"]
+        lat_var = dso.groups["geolocation"]["latitude"]
+        time_var = dso.groups["geolocation"]["time"]
+        time_units = time_var.units
 
-    ds.attrs["reference_time_string"] = dso.time_coverage_start
-    ds.attrs["granule_number"] = dso.granule_num
-    ds.attrs["scan_num"] = dso.scan_num
-
-    if ("pressure" in variable_dict) and "surface_pressure" not in variable_dict:
-        warnings.warn(
-            "Calculating pressure in TEMPO data requires surface_pressure. "
-            + "Adding surface_pressure to output variables"
+        ds["lon"] = (
+            ("x", "y"),
+            lon_var[:].squeeze(),
+            {"long_name": lon_var.long_name, "units": lon_var.units},
         )
-        variable_dict["surface_pressure"] = {}
 
-    for varname in variable_dict:
-        if varname in [
-            "main_data_quality_flag",
-            "vertical_column_troposphere",
-            "vertical_column_stratosphere",
-            "vertical_column_troposphere_uncertainty",
-            "vertical_column",
-            "vertical_column_uncertainty",
-        ]:
-            values_var = dso.groups["product"][varname]
-        elif varname in [
-            "latitude_bounds",
-            "longitude_bounds",
-            "solar_zenith_angle",
-            "solar_azimuth_angle",
-            "viewing_zenith_angle",
-            "viewing_azimuth_angle",
-            "relative_azimuth_angle",
-        ]:
-            values_var = dso.groups["geolocation"][varname]
-        elif varname in [
-            "vertical_column_total",
-            "vertical_column_total_uncertainty",
-            "fitted_slant_column",
-            "fitted_slant_column_uncertainty",
-            "snow_ice_fraction",
-            "terrain_height",
-            "ground_pixel_quality_flag",
-            "surface_pressure",
-            "tropopause_pressure",
-            "scattering_weights",
-            "gas_profile",
-            "albedo",
-            "temperature_profile",
-            "amf",
-            "amf_total",
-            "amf_diagnostic_flag",
-            "eff_cloud_fraction",
-            "amf_cloud_fraction",
-            "amf_cloud_pressure",
-            "amf_troposphere",
-            "amf_stratosphere",
-            "background_correction",
-        ]:
-            values_var = dso.groups["support_data"][varname]
-        elif varname in ["fit_rms_residual", "fit_convergence_flag"]:
-            values_var = dso.groups["qa_statistics"][varname]
-        values = values_var[:].squeeze()
+        ds["lat"] = (
+            ("x", "y"),
+            lat_var[:].squeeze(),
+            {"long_name": lat_var.long_name, "units": lat_var.units},
+        )
 
-        if "scale" in variable_dict[varname]:
-            values[:] = variable_dict[varname]["scale"] * values[:]
+        ds["time"] = (
+            ("time",),
+            num2pydate(time_var[:].squeeze(), time_units),
+            {"long_name": time_var.long_name},
+        )
 
-        if "minimum" in variable_dict[varname]:
-            minimum = variable_dict[varname]["minimum"]
-            values = np.ma.masked_less(values, minimum, copy=False)
+        ds = ds.set_coords(["time", "lon", "lat"])
 
-        if "maximum" in variable_dict[varname]:
-            maximum = variable_dict[varname]["maximum"]
-            values = np.ma.masked_greater(values, maximum, copy=False)
+        ds.attrs["reference_time_string"] = dso.time_coverage_start
+        ds.attrs["granule_number"] = dso.granule_num
+        ds.attrs["scan_num"] = dso.scan_num
 
-        if "corner" in values_var.dimensions:
-            ds[varname] = (("x", "y", "corner"), values, values_var.__dict__)
-        elif "swt_level" in values_var.dimensions:
-            ds[varname] = (("x", "y", "swt_level"), values, values_var.__dict__)
-        else:
-            ds[varname] = (("x", "y"), values, values_var.__dict__)
+        if ("pressure" in variable_dict) and "surface_pressure" not in variable_dict:
+            warnings.warn(
+                "Calculating pressure in TEMPO data requires surface_pressure. "
+                "Adding surface_pressure to output variables"
+            )
+            variable_dict["surface_pressure"] = {}
 
-        if "quality_flag_max" in variable_dict[varname]:
-            ds.attrs["quality_flag"] = varname
-            ds.attrs["quality_thresh_max"] = variable_dict[varname]["quality_flag_max"]
+        for varname in variable_dict:
 
-    dso.close()
+            if varname in [
+                "main_data_quality_flag",
+                "vertical_column_troposphere",
+                "vertical_column_stratosphere",
+                "vertical_column_troposphere_uncertainty",
+                "vertical_column",
+                "vertical_column_uncertainty",
+            ]:
+                values_var = dso.groups["product"][varname]
 
+            elif varname in [
+                "latitude_bounds",
+                "longitude_bounds",
+                "solar_zenith_angle",
+                "solar_azimuth_angle",
+                "viewing_zenith_angle",
+                "viewing_azimuth_angle",
+                "relative_azimuth_angle",
+            ]:
+                values_var = dso.groups["geolocation"][varname]
+
+            elif varname in [
+                "vertical_column_total",
+                "vertical_column_total_uncertainty",
+                "fitted_slant_column",
+                "fitted_slant_column_uncertainty",
+                "snow_ice_fraction",
+                "terrain_height",
+                "ground_pixel_quality_flag",
+                "surface_pressure",
+                "tropopause_pressure",
+                "scattering_weights",
+                "gas_profile",
+                "albedo",
+                "temperature_profile",
+                "amf",
+                "amf_total",
+                "amf_diagnostic_flag",
+                "eff_cloud_fraction",
+                "amf_cloud_fraction",
+                "amf_cloud_pressure",
+                "amf_troposphere",
+                "amf_stratosphere",
+                "background_correction",
+            ]:
+                values_var = dso.groups["support_data"][varname]
+
+            elif varname in ["fit_rms_residual", "fit_convergence_flag"]:
+                values_var = dso.groups["qa_statistics"][varname]
+
+            values = values_var[:].squeeze()
+
+            # scaling
+            if "scale" in variable_dict[varname]:
+                values = variable_dict[varname]["scale"] * values
+
+            # masking
+            if "minimum" in variable_dict[varname]:
+                values = np.ma.masked_less(values, variable_dict[varname]["minimum"], copy=False)
+
+            if "maximum" in variable_dict[varname]:
+                values = np.ma.masked_greater(values, variable_dict[varname]["maximum"], copy=False)
+
+            # store
+            if "corner" in values_var.dimensions:
+                ds[varname] = (("x", "y", "corner"), values, values_var.__dict__)
+
+            elif "swt_level" in values_var.dimensions:
+                ds[varname] = (("x", "y", "swt_level"), values, values_var.__dict__)
+
+            else:
+                ds[varname] = (("x", "y"), values, values_var.__dict__)
+
+            if "quality_flag_max" in variable_dict[varname]:
+                ds.attrs["quality_flag"] = varname
+                ds.attrs["quality_thresh_max"] = variable_dict[varname]["quality_flag_max"]
+
+    # pressure conversion
     if "surface_pressure" in variable_dict:
         if ds["surface_pressure"].attrs["units"] == "hPa":
             HPA2PA = 100
@@ -150,12 +157,33 @@ def _open_one_dataset(fname, variable_dict):
             ds["surface_pressure"].attrs["valid_min"] *= HPA2PA
             ds["surface_pressure"].attrs["valid_max"] *= HPA2PA
             ds["surface_pressure"].attrs["Eta_A"] *= HPA2PA
+
     if "pressure" in variable_dict:
         ds["pressure"] = calculate_pressure(ds)
 
+    # Generic PROPAGATING min/max screen: any requested variable given `min`
+    # and/or `max` masks ALL variables at pixels outside the range, e.g.
+    #   eff_cloud_fraction: {max: 0.2}, solar_zenith_angle: {max: 70},
+    #   main_data_quality_flag: {max: 0}
+    # Unlike the per-variable minimum/maximum keys (which self-mask one variable),
+    # this drops the whole pixel's retrieval across every variable.
+    for _sv, _spec in variable_dict.items():
+        if not isinstance(_spec, dict) or _sv not in ds:
+            continue
+        _lo, _hi = _spec.get("min"), _spec.get("max")
+        if _lo is None and _hi is None:
+            continue
+        _keep = xr.ones_like(ds[_sv], dtype=bool)
+        if _lo is not None:
+            _keep = _keep & (ds[_sv] >= float(_lo))
+        if _hi is not None:
+            _keep = _keep & (ds[_sv] <= float(_hi))
+        for _v in list(ds.data_vars):
+            if _v != _sv:
+                ds[_v] = ds[_v].where(_keep)
+
     return ds
-
-
+    
 def calculate_pressure(ds):
     """Calculates pressure at layer and delta_pressure of layer
 

--- a/monetio/sat/tropomi_l2.py
+++ b/monetio/sat/tropomi_l2.py
@@ -62,6 +62,28 @@ def _open_one_dataset(fname, variable_dict):
             dimensions.append(x)
     dso.close()
     ds = ensure_increasing_altitude(ds)
+
+    # Generic PROPAGATING min/max screen: any requested variable given `min`
+    # and/or `max` masks ALL variables at pixels outside the range, e.g.
+    #   eff_cloud_fraction: {max: 0.2}, solar_zenith_angle: {max: 70},
+    #   main_data_quality_flag: {max: 0}
+    # Unlike the per-variable minimum/maximum keys (which self-mask one variable),
+    # this drops the whole pixel's retrieval across every variable.
+    for _sv, _spec in variable_dict.items():
+        if not isinstance(_spec, dict) or _sv not in ds:
+            continue
+        _lo, _hi = _spec.get("min"), _spec.get("max")
+        if _lo is None and _hi is None:
+            continue
+        _keep = xr.ones_like(ds[_sv], dtype=bool)
+        if _lo is not None:
+            _keep = _keep & (ds[_sv] >= float(_lo))
+        if _hi is not None:
+            _keep = _keep & (ds[_sv] <= float(_hi))
+        for _v in list(ds.data_vars):
+            if _v != _sv:
+                ds[_v] = ds[_v].where(_keep)
+                
     return ds.transpose(*dimensions, ...)
 
 


### PR DESCRIPTION
A generic propagating quality screen for both L2 readers. Any requested obs variable given min/max in variable_dict masks all retrieval variables at pixels outside the range (drops the whole pixel, not just that one variable).

Why: The existing per-variable minimum/maximum and quality_flag/qa_thresh_* keys only self-mask a single variable. Screening satellite retrievals on cloud fraction / solar zenith / quality flag needs to remove the entire pixel so paired comparisons stay consistent across the column, uncertainty, geolocation, etc. e.g. eff_cloud_fraction: {max: 0.2}, solar_zenith_angle: {max: 70}, main_data_quality_flag: {max: 0}.

Backward-compatible: screens only activate when min/max are provided; existing keys unchanged.

Tested: via MELODIES-MONET satellite pairing (TEMPO NO2/HCHO, TROPOMI NO2/HCHO/CO) over CONUS.