### PR TITLE
Update hysplit.py for Numpy versions 2+

### DIFF
--- a/monetio/models/hysplit.py
+++ b/monetio/models/hysplit.py
@@ -37,6 +37,7 @@ Change log
 2023 12 Jan  AMC  get_thickness modified to calculate if the attribute specifying the vertical levels is bad
 2023 03 Mar  AMC  get_latlon modified. replace x>=180 with x>=180+lon_tolerance
 2023 03 Mar  AMC  get_latlongrid improved exception statements
+2026 04 Aug  ICA  parse_hdata6and7 and parse_hdata8 updated to reflect changes in numpy 2.0.0+
 
 
 """

--- a/monetio/models/hysplit.py
+++ b/monetio/models/hysplit.py
@@ -407,7 +407,7 @@ class ModelBin:
 
     def parse_hdata6and7(self, hdata6, hdata7, century):
         # if no data read then break out of the while loop.
-        if not hdata6:
+        if hdata6.size == 0:
             return False, None, None
         pdate1 = datetime.datetime(
             century + int(hdata6["oyear"][0]),
@@ -445,7 +445,7 @@ class ModelBin:
         """
         lev_name = hdata8a["lev"][0]
         col_name = hdata8a["poll"][0].decode("UTF-8")
-        edata = hdata8b.byteswap().newbyteorder()  # otherwise get endian error.
+        edata = hdata8b.byteswap().view(hdata8b.dtype.newbyteorder())  # otherwise get endian error.
         concframe = pd.DataFrame.from_records(edata)
         concframe["levels"] = lev_name
         concframe["time"] = pdate1


### PR DESCRIPTION
Hello, I ran into an issue when using a fresh install of monetio and the fixes were simple enough that I figured I would push them across. There are a couple lines in the hysplit.py module that aren't compatible with numpy versions 2.0 or greater, namely that ndarrays no longer parse as booleans and the way to change the byte order in the metadata of an ndarray also changed. I made the assumption that the hdata6 array-like passed to parse_hdata6and7() will always be an ndarray so that `if hdata6.size == 0` could be used instead of `if not hdata6` but if that isn't the case then there might be better solutions like casting to a list.